### PR TITLE
Ignore build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ ehthumbs.db
 Thumbs.db
 
 # Logs
-logs
+logs/
 *.log
 
 # Runtime data
@@ -77,3 +77,8 @@ public/Subject: Pitch: “{{track_title}}” by Rue
 decoded/
 decoded-mirror/
 decoded-mirror.bfg-report/
+
+# Additional build artifacts
+.aws-sam/
+lambda/growth-dashboard-lambda/
+archives/


### PR DESCRIPTION
## Summary
- update gitignore to fully exclude logs directory
- add build directories (.aws-sam, lambda/growth-dashboard-lambda, archives)

## Testing
- `npm test` *(fails: Missing script)*
- `cd frontend && npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68803a608d588328957db214dd629d8c