### PR TITLE
Fix dashboard lambda integrations

### DIFF
--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -144,7 +144,7 @@ Resources:
           Type: Api
           Properties:
             RestApiId: !Ref DecodedApi
-            Path: /dashboard/catalog
+            Path: /catalog
             Method: GET
 
   DashboardStreamsFunction:
@@ -335,7 +335,7 @@ Resources:
       Name: decodedmusic-api
       StageName: prod
       Cors:
-        AllowMethods: "POST,OPTIONS"
+        AllowMethods: "GET,POST,OPTIONS"
         AllowHeaders: "Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token"
         AllowOrigin: "https://decodedmusic.com"
 


### PR DESCRIPTION
## Summary
- grant API Gateway permission to invoke dashboard Lambdas
- call the permission helper when wiring integrations
- correct catalog path in template
- allow GET methods in API CORS settings

## Testing
- `bash -n fix-api-gateway.sh`

------
https://chatgpt.com/codex/tasks/task_b_6880559fe7e88328bbf6fdb0962cd358