### PR TITLE
Add deployment scripts and clean verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ out/
 
 # Deployment files
 deploy.sh
+!scripts/deployment/deploy.sh
 deployment-config.json
 lerna-debug.log*
 .pnpm-debug.log*

--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euo pipefail
+
+# Basic deployment script for the Decoded infrastructure
+STACK_NAME=${STACK_NAME:-decoded-stack}
+TEMPLATE_FILE=${TEMPLATE_FILE:-cloudformation/template.yaml}
+S3_BUCKET=${S3_BUCKET:-decoded-deploy-bucket}
+REGION=${AWS_REGION:-eu-central-1}
+
+build_artifacts() {
+  echo "Building artifacts..."
+  # Add project build commands here (e.g., npm run build)
+}
+
+package_template() {
+  echo "Packaging CloudFormation template..."
+  aws cloudformation package \
+    --template-file "$TEMPLATE_FILE" \
+    --s3-bucket "$S3_BUCKET" \
+    --output-template-file packaged.yaml \
+    --region "$REGION"
+}
+
+deploy_stack() {
+  echo "Deploying CloudFormation stack $STACK_NAME..."
+  aws cloudformation deploy \
+    --template-file packaged.yaml \
+    --stack-name "$STACK_NAME" \
+    --capabilities CAPABILITY_NAMED_IAM \
+    --region "$REGION"
+}
+
+main() {
+  build_artifacts
+  package_template
+  deploy_stack
+}
+
+main "$@"

--- a/scripts/verify-api-config.sh
+++ b/scripts/verify-api-config.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
+set -euo pipefail
 
-# REQUIRED: Set your region
-REGION="eu-central-1"
+REGION=${AWS_REGION:-eu-central-1}
 
-# List of REST API IDs and their names (adjust as needed)
+# List of REST API IDs and their names
 declare -A apis=(
   ["2h2oj7u446"]="DashboardAPI"
   ["0930nh8tai"]="DecodedMusicAPI"
@@ -16,58 +16,70 @@ declare -A apis=(
   ["y1zthsd7l0"]="prod-decodedmusic-api"
 )
 
-echo "🔍 Verifying API integrations and CORS setup..."
+get_resources() {
+  aws apigateway get-resources \
+    --rest-api-id "$1" \
+    --region "$REGION" \
+    --output json
+}
 
-for api_id in "${!apis[@]}"; do
-  name="${apis[$api_id]}"
-  echo -e "\n=== 🔧 API: $name ($api_id) ==="
+verify_resource() {
+  local api_id=$1
+  local resource=$2
+  local path=$(echo "$resource" | jq -r '.path')
+  local id=$(echo "$resource" | jq -r '.id')
 
-  # Get all resources
-  resources=$(aws apigateway get-resources --rest-api-id "$api_id" --region "$REGION" --output json)
+  echo -e "\n🛣️  Path: $path"
 
-  # Loop through each resource
-  echo "$resources" | jq -c '.items[]' | while read -r resource; do
-    path=$(echo "$resource" | jq -r '.path')
-    id=$(echo "$resource" | jq -r '.id')
-
-    echo -e "\n🛣️  Path: $path"
-
-    # List methods
-    methods=$(echo "$resource" | jq -r '.resourceMethods | keys[]?' 2>/dev/null)
-
-    for method in $methods; do
-      echo -n "  ➤ [$method] "
-
-      # Get integration info
-      integration=$(aws apigateway get-integration --rest-api-id "$api_id" --resource-id "$id" --http-method "$method" --region "$REGION" 2>/dev/null)
-      type=$(echo "$integration" | jq -r '.type // "NO_INTEGRATION"')
-
-      if [[ "$type" == "AWS_PROXY" || "$type" == "AWS" ]]; then
-        uri=$(echo "$integration" | jq -r '.uri')
-        echo "🔗 Lambda: $uri"
-      elif [[ "$type" == "MOCK" ]]; then
-        echo "⚠️ MOCK integration"
-      else
-        echo "❌ No integration"
-      fi
-    done
-
-    # Check if OPTIONS method has CORS headers
-    cors_headers=$(aws apigateway get-method --rest-api-id "$api_id" --resource-id "$id" --http-method OPTIONS --region "$REGION" 2>/dev/null | jq '.methodResponses."200".responseParameters')
-
-    if echo "$cors_headers" | grep -q 'Access-Control-Allow-Origin'; then
-      echo "  ✅ CORS: Access-Control-Allow-Origin present"
+  local methods=$(echo "$resource" | jq -r '.resourceMethods | keys[]?' 2>/dev/null)
+  for method in $methods; do
+    echo -n "  ➤ [$method] "
+    local integration=$(aws apigateway get-integration --rest-api-id "$api_id" --resource-id "$id" --http-method "$method" --region "$REGION" 2>/dev/null)
+    local type=$(echo "$integration" | jq -r '.type // "NO_INTEGRATION"')
+    if [[ "$type" == "AWS_PROXY" || "$type" == "AWS" ]]; then
+      local uri=$(echo "$integration" | jq -r '.uri')
+      echo "🔗 Lambda: $uri"
+    elif [[ "$type" == "MOCK" ]]; then
+      echo "⚠️ MOCK integration"
     else
-      echo "  ⚠️  CORS: NOT configured"
+      echo "❌ No integration"
     fi
   done
 
-  # Check if deployed to 'prod'
-  deployed=$(aws apigateway get-stage --rest-api-id "$api_id" --stage-name prod --region "$REGION" 2>/dev/null)
+  local cors_headers=$(aws apigateway get-method --rest-api-id "$api_id" --resource-id "$id" --http-method OPTIONS --region "$REGION" 2>/dev/null | jq '.methodResponses."200".responseParameters')
+  if echo "$cors_headers" | grep -q 'Access-Control-Allow-Origin'; then
+    echo "  ✅ CORS: Access-Control-Allow-Origin present"
+  else
+    echo "  ⚠️  CORS: NOT configured"
+  fi
+}
+
+verify_stage() {
+  local api_id=$1
+  local deployed=$(aws apigateway get-stage --rest-api-id "$api_id" --stage-name prod --region "$REGION" 2>/dev/null)
   if [[ -n "$deployed" ]]; then
     echo "🚀 Deployed to stage: prod"
   else
     echo "⚠️  NOT deployed to 'prod' stage"
   fi
+}
 
-done
+verify_api() {
+  local api_id=$1
+  local name=$2
+  echo -e "\n=== 🔧 API: $name ($api_id) ==="
+  local resources=$(get_resources "$api_id")
+  echo "$resources" | jq -c '.items[]' | while read -r resource; do
+    verify_resource "$api_id" "$resource"
+  done
+  verify_stage "$api_id"
+}
+
+main() {
+  echo "🔍 Verifying API integrations and CORS setup..."
+  for api_id in "${!apis[@]}"; do
+    verify_api "$api_id" "${apis[$api_id]}"
+  done
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- allow version controlled deployment script
- add deploy.sh with functional stubs
- refactor verify-api-config.sh into modular functions

## Testing
- `bash -n scripts/verify-api-config.sh`
- `bash -n scripts/deployment/deploy.sh`
- `shellcheck scripts/verify-api-config.sh` *(shows warnings)*

------
https://chatgpt.com/codex/tasks/task_b_68815ece973883288ab1eb36af9fc399