### PR TITLE
Update deploy script with CloudFront invalidation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -308,10 +308,13 @@ After committing changes to GitHub you can deploy the build output to the Genera
 ### Automated deploy script
 
 The repository includes `automate-deploy-sync.sh` to perform the above steps in
-one command. Provide your target bucket via `DEPLOY_BUCKET`:
+one command. Provide your target bucket via `DEPLOY_BUCKET`. To automatically
+invalidate a CloudFront distribution after syncing, also set
+`CLOUDFRONT_DISTRIBUTION_ID`:
 
 ```bash
-DEPLOY_BUCKET=decoded-genai-stack-webappne-websitebucket4326d7c2-jvplfkkey9mb ./automate-deploy-sync.sh
+DEPLOY_BUCKET=decoded-genai-stack-webappne-websitebucket4326d7c2-jvplfkkey9mb \
+CLOUDFRONT_DISTRIBUTION_ID=E11YR13TCZW98X ./automate-deploy-sync.sh
 ```
 
 The CloudFront distribution <https://d340ynz7yytwls.cloudfront.net/> (ID `E11YR13TCZW98X`, ARN `arn:aws:cloudfront::396913703024:distribution/E11YR13TCZW98X`) will serve the updated site once the files are uploaded.

--- a/scripts/integration/automate-deploy-sync.sh
+++ b/scripts/integration/automate-deploy-sync.sh
@@ -6,13 +6,15 @@ set -euo pipefail
 
 BUCKET="${DEPLOY_BUCKET:-}"
 REGION="${AWS_REGION:-eu-central-1}"
+# Optional CloudFront distribution ID for cache invalidation
+DISTRIBUTION_ID="${CLOUDFRONT_DISTRIBUTION_ID:-}"
 
 if [ -z "$BUCKET" ]; then
   echo "Usage: DEPLOY_BUCKET=your-bucket ./automate-deploy-sync.sh" >&2
   exit 1
 fi
 
-echo "[1/5] Updating repository..."
+echo "[1/6] Updating repository..."
 # Ensure repository is clean
 if ! git diff-index --quiet HEAD --; then
   echo "Uncommitted changes detected. Stash or commit them before deploying." >&2
@@ -21,18 +23,23 @@ fi
 
 git pull --rebase
 
-echo "[2/5] Installing dependencies..."
+echo "[2/6] Installing dependencies..."
 if [ -f package-lock.json ]; then
   npm ci
 else
   npm install
 fi
 
-echo "[3/5] Building project..."
+echo "[3/6] Building project..."
 rm -rf build
 npm run build
 
-echo "[4/5] Syncing build to s3://$BUCKET (region: $REGION)..."
+echo "[4/6] Syncing build to s3://$BUCKET (region: $REGION)..."
 aws s3 sync build/ "s3://$BUCKET" --region "$REGION" --delete
 
-echo "[5/5] Deployment complete."
+if [ -n "$DISTRIBUTION_ID" ]; then
+  echo "[5/6] Creating CloudFront invalidation for distribution $DISTRIBUTION_ID..."
+  aws cloudfront create-invalidation --distribution-id "$DISTRIBUTION_ID" --paths "/*"
+fi
+
+echo "[6/6] Deployment complete."


### PR DESCRIPTION
## Summary
- add optional CloudFront invalidation step to `automate-deploy-sync.sh`
- document usage of `CLOUDFRONT_DISTRIBUTION_ID` in README

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_68818154fb148328b5d8af99c216c032