### PR TITLE
Fix jsconfig baseUrl

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "baseUrl": "src",
+    "baseUrl": "frontend/src",
     "jsx": "react"
   },
-  "include": ["src"]
+  "include": ["frontend/src"]
 }


### PR DESCRIPTION
## Summary
- point jsconfig to frontend source files

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_68818a76e80483288b07e6cd3f1d51c0