### PR TITLE
Fix inconsistent Cognito token key

### DIFF
--- a/backend/services/DynamoDBService.js
+++ b/backend/services/DynamoDBService.js
@@ -8,7 +8,7 @@ class DynamoDBService {
     async getArtistPortfolio(artistId) {
         // Ensure token is captured
         getCognitoTokenFromUrl();
-        const token = localStorage.getItem('cognito_id_token');
+        const token = localStorage.getItem('cognito_token');
         const response = await fetch(`${process.env.REACT_APP_API_ENDPOINT}/artist/portfolio`, {
             method: 'POST',
             headers: {
@@ -24,7 +24,7 @@ class DynamoDBService {
     // Get track analytics
     async getTrackAnalytics(artistId) {
         getCognitoTokenFromUrl();
-        const token = localStorage.getItem('cognito_id_token');
+        const token = localStorage.getItem('cognito_token');
         const response = await fetch(`${process.env.REACT_APP_API_ENDPOINT}/track/analytics`, {
             method: 'POST',
             headers: {
@@ -39,7 +39,7 @@ class DynamoDBService {
     // Get AI recommendations
     async getAIRecommendations(artistId) {
         getCognitoTokenFromUrl();
-        const token = localStorage.getItem('cognito_id_token');
+        const token = localStorage.getItem('cognito_token');
         const response = await fetch(`${process.env.REACT_APP_API_ENDPOINT}/artist/recommendations`, {
             method: 'POST',
             headers: {
@@ -54,7 +54,7 @@ class DynamoDBService {
     // Update artist data
     async updateArtistData(artistId, data) {
         getCognitoTokenFromUrl();
-        const token = localStorage.getItem('cognito_id_token');
+        const token = localStorage.getItem('cognito_token');
         const response = await fetch(`${process.env.REACT_APP_API_ENDPOINT}/artist/update`, {
             method: 'POST',
             headers: {
@@ -68,7 +68,7 @@ class DynamoDBService {
 
     // Save contact message
     async saveContactMessage(data) {
-        const token = localStorage.getItem('cognito_id_token');
+        const token = localStorage.getItem('cognito_token');
         const response = await fetch(`${process.env.REACT_APP_API_ENDPOINT}/contact/save`, {
             method: 'POST',
             headers: {

--- a/backend/services/apiService.js
+++ b/backend/services/apiService.js
@@ -2,7 +2,7 @@ const API_BASE = process.env.REACT_APP_API_BASE || 'https://2h2oj7u446.execute-a
 
 const apiService = {
   getDashboardData: async () => {
-    const token = localStorage.getItem('cognito_id_token');
+    const token = localStorage.getItem('cognito_token');
     if (!token) {
       throw new Error('No Cognito token found. Please log in.');
     }
@@ -24,7 +24,7 @@ const apiService = {
   },
 
   getSpotifyData: async () => {
-    const token = localStorage.getItem('cognito_id_token');
+    const token = localStorage.getItem('cognito_token');
     if (!token) {
       throw new Error('No Cognito token found. Please log in.');
     }

--- a/frontend/src/api/apiconfig.js
+++ b/frontend/src/api/apiconfig.js
@@ -23,7 +23,7 @@ const DEFAULT_HEADERS = {
 };
 
 function getToken() {
-  return localStorage.getItem('cognito_id_token') || localStorage.getItem('spotify_token');
+  return localStorage.getItem('cognito_token') || localStorage.getItem('spotify_token');
 }
 
 async function fetchWithAuth(url, options = {}) {
@@ -42,7 +42,7 @@ async function fetchWithAuth(url, options = {}) {
 
 export const DashboardAPI = {
   getAccounting: async ({ artistId }) => {
-    const token = window.localStorage.getItem('cognito_id_token');
+    const token = window.localStorage.getItem('cognito_token');
     const res = await fetch(
       `${API_ENDPOINTS.DASHBOARD_BASE}/accounting?artistId=${artistId}`,
       {
@@ -93,7 +93,7 @@ export const DashboardAPI = {
 
 export const DynamoDBAPI = {
   getArtistPortfolio: async (artistId) => {
-    const token = localStorage.getItem('cognito_id_token');
+    const token = localStorage.getItem('cognito_token');
     const response = await fetch(`${process.env.REACT_APP_API_ENDPOINT}/artist/portfolio`, {
       method: 'POST',
       headers: {
@@ -106,7 +106,7 @@ export const DynamoDBAPI = {
   },
 
   getTrackAnalytics: async (artistId) => {
-    const token = localStorage.getItem('cognito_id_token');
+    const token = localStorage.getItem('cognito_token');
     const response = await fetch(`${process.env.REACT_APP_API_ENDPOINT}/track/analytics`, {
       method: 'POST',
       headers: {
@@ -119,7 +119,7 @@ export const DynamoDBAPI = {
   },
 
   getAIRecommendations: async (artistId) => {
-    const token = localStorage.getItem('cognito_id_token');
+    const token = localStorage.getItem('cognito_token');
     const response = await fetch(`${process.env.REACT_APP_API_ENDPOINT}/artist/recommendations`, {
       method: 'POST',
       headers: {
@@ -132,7 +132,7 @@ export const DynamoDBAPI = {
   },
 
   updateArtistData: async (artistId, data) => {
-    const token = localStorage.getItem('cognito_id_token');
+    const token = localStorage.getItem('cognito_token');
     const response = await fetch(`${process.env.REACT_APP_API_ENDPOINT}/artist/update`, {
       method: 'POST',
       headers: {

--- a/frontend/src/api/dashboard.js
+++ b/frontend/src/api/dashboard.js
@@ -1,7 +1,7 @@
 const API_BASE = process.env.REACT_APP_API_URL || 'https://2h2oj7u446.execute-api.eu-central-1.amazonaws.com/prod';
 
 function getToken() {
-  return localStorage.getItem('cognito_id_token') || localStorage.getItem('spotify_token');
+  return localStorage.getItem('cognito_token') || localStorage.getItem('spotify_token');
 }
 
 async function fetchWithAuth(url, options = {}) {
@@ -20,7 +20,7 @@ async function fetchWithAuth(url, options = {}) {
 
 export const DashboardAPI = {
   getAccounting: async ({ artistId }) => {
-    const token = window.localStorage.getItem('cognito_id_token');
+    const token = window.localStorage.getItem('cognito_token');
     const res = await fetch(
       `${process.env.REACT_APP_DASHBOARD_ACCOUNTING}?artistId=${artistId}`,
       {

--- a/frontend/src/pages/ArtistDashboard.js
+++ b/frontend/src/pages/ArtistDashboard.js
@@ -64,7 +64,7 @@ function ArtistDashboard() {
   }, []);
 
   const spotifyToken = window.localStorage.getItem('spotify_token');
-  const cognitoToken = window.localStorage.getItem('cognito_id_token');
+  const cognitoToken = window.localStorage.getItem('cognito_token');
   const token = spotifyToken || cognitoToken;
 
   if (!token) {

--- a/frontend/src/services/CognitoAuthService.js
+++ b/frontend/src/services/CognitoAuthService.js
@@ -34,7 +34,7 @@ class CognitoAuthService {
             user.authenticateUser(authDetails, {
                 onSuccess: (result) => {
                     const token = result.getIdToken().getJwtToken();
-                    localStorage.setItem('cognitoToken', token);
+                    localStorage.setItem('cognito_token', token);
                     resolve({ success: true, user: email, token });
                 },
                 onFailure: (err) => {
@@ -70,7 +70,7 @@ class CognitoAuthService {
         const currentUser = userPool.getCurrentUser();
         if (currentUser) {
             currentUser.signOut();
-            localStorage.removeItem('cognitoToken');
+            localStorage.removeItem('cognito_token');
         }
     }
 }

--- a/frontend/src/utils/getCognitoToken.js
+++ b/frontend/src/utils/getCognitoToken.js
@@ -4,9 +4,9 @@ export function getCognitoTokenFromUrl() {
   const token = new URLSearchParams(hash.substring(1)).get("id_token");
 
   if (token) {
-    localStorage.setItem("cognito_id_token", token);
+    localStorage.setItem("cognito_token", token);
     window.history.replaceState(null, "", window.location.pathname); // clean URL
   }
 
-  return token || localStorage.getItem("cognito_id_token");
+  return token || localStorage.getItem("cognito_token");
 }

--- a/scripts/frontend-token-check.js
+++ b/scripts/frontend-token-check.js
@@ -1,5 +1,5 @@
 // Validate React frontend token usage
-const token = localStorage.getItem("cognito_id_token");
+const token = localStorage.getItem("cognito_token");
 
 if (!token) {
     console.error("❌ No Cognito token found in localStorage");


### PR DESCRIPTION
## Summary
- use a single `cognito_token` key throughout frontend and backend

## Testing
- `npm test --silent`
- `npm run build --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_6882c4ae341c8328bb05168d141cd2e7