### PR TITLE
Connect buzz research with marketing panel

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -58,6 +58,8 @@ The `npm run research` script (see `scripts/musicManagementResearcher.js`)
 scans public news sources for updates on labels, sync opportunities, artist
 deals, disputes, catalog sales, and contract releases. Results are summarized
 using AWS Bedrock and saved to `industry_buzz.txt`.
+The file is also copied to `frontend/public/industry_buzz.txt` so the React
+Marketing Panel can load the latest summary.
 
 Copy `.env.example` to `.env` and fill in the required keys. Secrets such as API tokens should be stored in **AWS Secrets Manager** or **SSM Parameter Store** and referenced by name in the `.env` file. The front-end loads these variables using the `dotenv` package during local development, so be sure your CI/CD pipeline defines the same keys for production builds. Alternatively you can set the `NEWS_API_KEY` environment variable and AWS credentials before running:
 

--- a/frontend/src/components/MarketingPanel.jsx
+++ b/frontend/src/components/MarketingPanel.jsx
@@ -1,5 +1,21 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 export default function MarketingPanel({ user }) {
-  return <div>👋 Marketing data for {user?.username || 'Guest'}</div>;
+  const [buzz, setBuzz] = useState('');
+
+  useEffect(() => {
+    fetch('/industry_buzz.txt')
+      .then((res) => (res.ok ? res.text() : ''))
+      .then((text) => setBuzz(text.trim()))
+      .catch(() => {
+        // ignore fetch errors in local development
+      });
+  }, []);
+
+  return (
+    <div>
+      <p>👋 Marketing data for {user?.username || 'Guest'}</p>
+      {buzz && <pre style={{ whiteSpace: 'pre-wrap' }}>{buzz}</pre>}
+    </div>
+  );
 }

--- a/scripts/musicManagementResearcher.js
+++ b/scripts/musicManagementResearcher.js
@@ -64,7 +64,11 @@ async function run() {
   const news = await gatherNews();
   const text = news.map(a => `- ${a.title} (${a.source.name})`).join('\n');
   const summary = await summarizeWithBedrock(text);
+  // Save to project root for backwards compatibility
   await fs.writeFile('industry_buzz.txt', summary);
+  // Also output to the React public folder so the marketing panel can load it
+  const reactPath = path.join(__dirname, '..', 'frontend', 'public', 'industry_buzz.txt');
+  await fs.writeFile(reactPath, summary);
   console.log('Industry Buzz saved. Share via Threads API: https://developers.facebook.com/docs/threads-api');
 }
 


### PR DESCRIPTION
## Summary
- write industry_buzz.txt to React public folder in `musicManagementResearcher.js`
- display the latest buzz in `MarketingPanel`
- document that the research output is copied to the React app

## Testing
- `npm install --prefix frontend`
- `npm run build --prefix frontend` *(passed)*
- `node scripts/musicManagementResearcher.js` *(failed: Cannot find module '@aws-sdk/client-bedrock-runtime')*

------
https://chatgpt.com/codex/tasks/task_b_6882d868b82c832881f9d019e68b63d1