### PR TITLE
Fix CORS helper module

### DIFF
--- a/lambda/shared/cors-headers.js
+++ b/lambda/shared/cors-headers.js
@@ -1,9 +1,30 @@
+const headers = {
+    'Access-Control-Allow-Origin': 'https://decodedmusic.com',
+    'Access-Control-Allow-Headers': 'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token',
+    'Access-Control-Allow-Methods': 'GET,POST,OPTIONS,PUT,DELETE'
+};
+
+function successResponse(data) {
+    return {
+        statusCode: 200,
+        headers,
+        body: JSON.stringify(data)
+    };
+}
+
+function errorResponse(error, statusCode = 500) {
+    return {
+        statusCode,
+        headers,
+        body: JSON.stringify({
+            error: error.message || error,
+            timestamp: new Date().toISOString()
+        })
+    };
+}
+
 module.exports = {
-    headers: {
-        'Access-Control-Allow-Origin': 'https://decodedmusic.com',
-        'Access-Control-Allow-Headers': 'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token',
-        'Access-Control-Allow-Methods': 'GET,POST,OPTIONS,PUT,DELETE'
-    },
-    successResponse: (data) => ({ statusCode: 200, headers: this.headers, body: JSON.stringify(data) }),
-    errorResponse: (error, statusCode = 500) => ({ statusCode, headers: this.headers, body: JSON.stringify({ error: error.message || error, timestamp: new Date().toISOString() }) })
+    headers,
+    successResponse,
+    errorResponse
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "scripts": {
     "start": "npm start --prefix frontend",
-    "build": "npm run build --prefix frontend"
+    "build": "npm run build --prefix frontend",
+    "test": "node tests/cors-headers.test.js"
   }
 }

--- a/tests/cors-headers.test.js
+++ b/tests/cors-headers.test.js
@@ -1,0 +1,18 @@
+const assert = require('assert');
+const { headers, successResponse, errorResponse } = require('../lambda/shared/cors-headers');
+
+const data = { ok: true };
+const success = successResponse(data);
+assert.strictEqual(success.statusCode, 200);
+assert.deepStrictEqual(success.headers, headers);
+assert.strictEqual(success.body, JSON.stringify(data));
+
+const err = new Error('oops');
+const failure = errorResponse(err, 400);
+assert.strictEqual(failure.statusCode, 400);
+assert.deepStrictEqual(failure.headers, headers);
+const parsed = JSON.parse(failure.body);
+assert.strictEqual(parsed.error, err.message);
+assert.ok(parsed.timestamp);
+
+console.log('cors-headers tests passed');


### PR DESCRIPTION
## Summary
- fix `cors-headers` helpers to avoid wrong `this` usage
- add small Node.js test and wire it in npm scripts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688415fee2cc8324987426e145b65ca1