### PR TITLE
Fix Windows path in S3 upload script

### DIFF
--- a/scripts/uploadAllToS3.js
+++ b/scripts/uploadAllToS3.js
@@ -6,7 +6,8 @@ const AWS = require('aws-sdk');
 const BUCKET_NAME = 'decodedmusic-lambda-code';
 
 const s3 = new AWS.S3();
-const lambdaDir = path.join('C:', 'decoded', 'backend', 'lambda');
+// Resolve the lambda directory relative to this script so it works on any OS
+const lambdaDir = path.join(__dirname, '..', 'backend', 'lambda');
 
 fs.readdir(lambdaDir, (err, files) => {
   if (err) {


### PR DESCRIPTION
## Summary
- fix `scripts/uploadAllToS3.js` to use a relative path
- confirm the resolved directory on Unix and Windows

## Testing
- `npm test`
- `node - <<'NODE'
const path = require('path');
const dir = path.join(process.cwd(), 'scripts');
const lambdaDir = path.join(dir, '..', 'backend', 'lambda');
console.log(lambdaDir);
const winScriptDir = 'C:\\decoded\\scripts';
const winLambdaDir = path.win32.join(winScriptDir, '..', 'backend', 'lambda');
console.log(winLambdaDir);
NODE`

------
https://chatgpt.com/codex/tasks/task_b_688419f853648324b2aa97497c927ade