### PR TITLE
Add pitch & admin pages

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -9,6 +9,8 @@ import CatalogPanel from './components/catalog/CatalogPanel.jsx';
 import AnalyticsPanel from './components/AnalyticsPanel.jsx';
 import SpotifyModule from './components/SpotifyModule.js';
 import BuzzPage from './pages/BuzzPage.js';
+import PitchPage from './pages/PitchPage.jsx';
+import Admin from './pages/Admin.jsx';
 import ContactForm from './components/ContactForm.jsx';
 import About from './pages/About.jsx';
 import MarketingHub from './pages/MarketingHub.jsx';
@@ -41,7 +43,9 @@ function App() {
             <Link to="/analytics"><button>Analytics</button></Link>
             <Link to="/spotify"><button>Spotify</button></Link>
             <Link to="/buzz"><button>Buzz</button></Link>
+            <Link to="/pitch"><button>Pitch</button></Link>
             <Link to="/marketing-hub"><button>Marketing Hub</button></Link>
+            <Link to="/admin"><button>Admin</button></Link>
             <button onClick={signOut}>Sign Out</button>
           </>
         )}
@@ -95,7 +99,9 @@ function App() {
             isAuthenticated ? <SpotifyModule user={user} /> : <Navigate to="/login" replace />
           }
         />
+        <Route path="/pitch" element={<PitchPage />} />
         <Route path="/buzz" element={<BuzzPage />} />
+        <Route path="/admin" element={isAuthenticated ? <Admin /> : <Navigate to="/login" replace />} />
         <Route path="/contact" element={<ContactForm />} />
         <Route path="/about" element={<About />} />
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/pages/Admin.jsx
+++ b/frontend/src/pages/Admin.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import PageLayout from '../layouts/PageLayout.js';
+
+function Admin() {
+  return (
+    <PageLayout>
+      <div style={{ maxWidth: 680, margin: '0 auto', padding: '2rem 1rem' }}>
+        <h1 style={{ textAlign: 'center', marginBottom: '1rem' }}>Admin Panel</h1>
+        <p>Internal usage stats will appear here.</p>
+      </div>
+    </PageLayout>
+  );
+}
+
+export default Admin;

--- a/frontend/src/pages/PitchPage.jsx
+++ b/frontend/src/pages/PitchPage.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import PageLayout from '../layouts/PageLayout.js';
+import PitchSubmissionForm from '../components/catalog/PitchSubmissionForm.jsx';
+
+function PitchPage() {
+  return (
+    <PageLayout>
+      <div style={{ maxWidth: 680, margin: '0 auto', padding: '2rem 1rem' }}>
+        <h1 style={{ textAlign: 'center', marginBottom: '1rem' }}>Submit a Pitch</h1>
+        <PitchSubmissionForm />
+      </div>
+    </PageLayout>
+  );
+}
+
+export default PitchPage;


### PR DESCRIPTION
## Summary
- add missing PitchPage and Admin page components
- expose `/pitch` and `/admin` routes
- link new pages from navigation bar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68844129f3dc8324909c528a4a78e847