### PR TITLE
Fix growth lambda CORS and parameterize API stage

### DIFF
--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -333,7 +333,7 @@ Resources:
     Type: AWS::Serverless::Api
     Properties:
       Name: decodedmusic-api
-      StageName: prod
+      StageName: !Ref EnvName
       Cors:
         AllowMethods: "GET,POST,OPTIONS"
         AllowHeaders: "Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token"
@@ -342,8 +342,8 @@ Resources:
 Outputs:
   CatalogApi:
     Description: "Catalog endpoint"
-    Value: !Sub "https://${DecodedApi}.execute-api.${AWS::Region}.amazonaws.com/prod/dashboard/catalog"
+    Value: !Sub "https://${DecodedApi}.execute-api.${AWS::Region}.amazonaws.com/${EnvName}/dashboard/catalog"
 
   DashboardApi:
     Description: "Dashboard streams endpoint"
-    Value: !Sub "https://${DecodedApi}.execute-api.${AWS::Region}.amazonaws.com/prod/dashboard/streams"
+    Value: !Sub "https://${DecodedApi}.execute-api.${AWS::Region}.amazonaws.com/${EnvName}/dashboard/streams"

--- a/lambda/growth-dashboard-lambda/lambda_function.py
+++ b/lambda/growth-dashboard-lambda/lambda_function.py
@@ -1,12 +1,22 @@
 import json
 import subprocess
 
-def lambda_handler(event, context):
-    artist_id = event.get("queryStringParameters", {}).get("artistId", "")
+CORS_HEADERS = {
+    "Access-Control-Allow-Origin": "https://decodedmusic.com",
+    "Access-Control-Allow-Headers": "Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token",
+    "Access-Control-Allow-Methods": "GET,POST,OPTIONS"
+}
 
+
+def lambda_handler(event, context):
+    if event.get("httpMethod") == "OPTIONS":
+        return {"statusCode": 200, "headers": CORS_HEADERS, "body": ""}
+
+    artist_id = event.get("queryStringParameters", {}).get("artistId", "")
     if not artist_id:
         return {
             "statusCode": 400,
+            "headers": CORS_HEADERS,
             "body": json.dumps({"error": "artistId is required"})
         }
 
@@ -16,11 +26,12 @@ def lambda_handler(event, context):
         ])
         return {
             "statusCode": 200,
-            "headers": {"Content-Type": "application/json"},
+            "headers": {**CORS_HEADERS, "Content-Type": "application/json"},
             "body": result.decode("utf-8")
         }
     except subprocess.CalledProcessError as e:
         return {
             "statusCode": 500,
+            "headers": CORS_HEADERS,
             "body": json.dumps({"error": str(e)})
         }


### PR DESCRIPTION
## Summary
- return CORS headers from `growth-dashboard-lambda`
- use the `EnvName` parameter for the API Gateway stage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688446c420b08324882388f296552217