### PR TITLE
Add automation scheduler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2,5 +2,32 @@
   "name": "decodedGIT",
   "lockfileVersion": 3,
   "requires": true,
-  "packages": {}
+  "packages": {
+    "": {
+      "dependencies": {
+        "node-cron": "^3.0.3"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "license": "ISC",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "scripts": {
     "start": "npm start --prefix frontend",
     "build": "npm run build --prefix frontend",
-    "test": "node tests/cors-headers.test.js"
+    "test": "node tests/cors-headers.test.js",
+    "schedule": "node scripts/automationScheduler.js"
+  },
+  "dependencies": {
+    "node-cron": "^3.0.3"
   }
 }

--- a/scripts/automationScheduler.js
+++ b/scripts/automationScheduler.js
@@ -1,0 +1,28 @@
+const path = require('path');
+const { spawn } = require('child_process');
+const cron = require('node-cron');
+
+function runScript(relPath) {
+  const scriptPath = path.join(__dirname, relPath);
+  const child = spawn(process.execPath, [scriptPath], { stdio: 'inherit' });
+  child.on('close', code => {
+    if (code !== 0) {
+      console.error(`${relPath} exited with code ${code}`);
+    }
+  });
+}
+
+// Industry Buzz: daily at 07:00 UTC
+cron.schedule('0 7 * * *', () => {
+  console.log(`[${new Date().toISOString()}] Running musicManagementResearcher`);
+  runScript('musicManagementResearcher.js');
+});
+
+// Weekly Analytics Snapshot: Tuesdays at 12:00 UTC
+cron.schedule('0 12 * * 2', () => {
+  console.log(`[${new Date().toISOString()}] Running weeklyStatsLogger`);
+  runScript('../backend/handlers/weeklyStatsLogger.js');
+});
+
+console.log('Automation scheduler started.');
+


### PR DESCRIPTION
## Summary
- schedule Industry Buzz script daily and Weekly Stats logger weekly
- add `node-cron` dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6884550ed79c832493514e701900e38f