### PR TITLE
Use S3 favicon

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,16 +20,16 @@ The page is built as a sequence of components, each representing a distinct sect
 **Project Layout:**
 
 * `src/` – React components and pages.
-* `public/` – static files served by the app such as `index.html` and `favicon.png`.
+* `public/` – static files served by the app such as `index.html` and `favicon.ico`.
 * `scripts/` – automation and deployment scripts.
 
-To update the site icon, replace `public/favicon.png` with your image and ensure `public/index.html` contains:
+To update the site icon, replace `public/favicon.ico` with your image and ensure `public/index.html` contains:
 
 ```html
-<link rel="icon" href="%PUBLIC_URL%/favicon.png" />
+<link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
 ```
 
-Remove any `favicon.ico` in `public/` before building so the updated icon appears in the browser.
+The favicon is stored in the S3 bucket `decoded-genai-stack-webappne-websitebucket4326d7c2-jvplfkkey9mb`.
 
 **Conceptual Backend Integration:**
 

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -10,7 +10,7 @@
     />
 
     <!-- Icons -->
-    <link rel="icon" href="/favicon.png" />
+    <link rel="icon" href="/favicon.ico" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
 

--- a/scripts/outline.txt
+++ b/scripts/outline.txt
@@ -2,7 +2,7 @@ music-analytics-dashboard/
 ├── frontend/
 │   ├── public/
 │   │   ├── index.html
-│   │   ├── favicon.png
+│   │   ├── favicon.ico
 │   │   └── manifest.json
 │   ├── src/
 │   │   ├── components/

--- a/scripts/update-favicon.sh
+++ b/scripts/update-favicon.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 set -x
 
-# Download the latest favicon.png from GitHub
-curl -L -o public/favicon.png https://github.com/1000grams/decoded/raw/main/public/favicon.png
+# Download the latest favicon.ico from the S3 bucket
+curl -L -o public/favicon.ico \
+  https://decoded-genai-stack-webappne-websitebucket4326d7c2-jvplfkkey9mb.s3.amazonaws.com/favicon.ico
 
 # Ensure the correct <link> is present in index.html
-grep -q '<link rel="icon" href="%PUBLIC_URL%/favicon.png"' public/index.html || \
-  echo '<link rel="icon" href="%PUBLIC_URL%/favicon.png" />' >> public/index.html
+grep -q '<link rel="icon" href="%PUBLIC_URL%/favicon.ico"' public/index.html || \
+  echo '<link rel="icon" href="%PUBLIC_URL%/favicon.ico" />' >> public/index.html
 
-# Remove old favicon.ico
-rm -f public/favicon.ico
+# Remove old favicon.png
+rm -f public/favicon.png
 
-echo "Favicon updated from GitHub. Ready to build."
+echo "Favicon updated from S3. Ready to build."


### PR DESCRIPTION
## Summary
- fetch favicon.ico from S3 instead of GitHub
- link to favicon.ico in index.html
- document new favicon location
- adjust outline

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6885567ec2cc8324a97a9043d8e89874