### PR TITLE
Fix MarketingPanel HTML response

### DIFF
--- a/frontend/src/components/MarketingPanel.jsx
+++ b/frontend/src/components/MarketingPanel.jsx
@@ -5,7 +5,17 @@ export default function MarketingPanel({ user }) {
 
   useEffect(() => {
     fetch('/industry_buzz.txt')
-      .then((res) => (res.ok ? res.text() : ''))
+      .then(async (res) => {
+        if (!res.ok) {
+          return '';
+        }
+        const contentType = res.headers.get('content-type');
+        if (!contentType || !contentType.includes('text')) {
+          // Likely an HTML fallback page – don't display it
+          return '';
+        }
+        return await res.text();
+      })
       .then((text) => setBuzz(text.trim()))
       .catch(() => {
         // ignore fetch errors in local development


### PR DESCRIPTION
## Summary
- improve `MarketingPanel` fetch logic to ignore HTML fallback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688688192430832483cf26b7695e6d00