### PR TITLE
Fix CORS headers for Lambda responses

### DIFF
--- a/backend/handlers/attributionHandler.js
+++ b/backend/handlers/attributionHandler.js
@@ -45,5 +45,5 @@ exports.handler = async (event) => {
 };
 
 function response(statusCode, body) {
-  return { statusCode, headers: { 'Access-Control-Allow-Origin': '*' }, body: JSON.stringify(body) };
+  return { statusCode, headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }, body: JSON.stringify(body) };
 }

--- a/backend/handlers/catalogHandler.js
+++ b/backend/handlers/catalogHandler.js
@@ -45,7 +45,7 @@ exports.handler = async (event) => {
 function response(statusCode, body) {
   return {
     statusCode,
-    headers: { 'Access-Control-Allow-Origin': '*' },
+    headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
     body: JSON.stringify(body),
   };
 }

--- a/backend/handlers/cognitoCheck.js
+++ b/backend/handlers/cognitoCheck.js
@@ -24,7 +24,7 @@ exports.handler = async (event) => {
     return {
       statusCode: 401,
       body: JSON.stringify({ message: 'Missing or invalid Authorization header' }),
-      headers: { 'Access-Control-Allow-Origin': '*' }
+      headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }
     };
   }
   const token = authHeader.split(' ')[1];
@@ -34,14 +34,14 @@ exports.handler = async (event) => {
         resolve({
           statusCode: 401,
           body: JSON.stringify({ message: 'Invalid token', error: err.message }),
-          headers: { 'Access-Control-Allow-Origin': '*' }
+          headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }
         });
       } else {
         // Token is valid, you can add your business logic here
         resolve({
           statusCode: 200,
           body: JSON.stringify({ message: 'Token is valid', user: decoded }),
-          headers: { 'Access-Control-Allow-Origin': '*' }
+          headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }
         });
       }
     });

--- a/backend/handlers/contactHandler.js
+++ b/backend/handlers/contactHandler.js
@@ -19,14 +19,14 @@ exports.handler = async (event) => {
     return {
       statusCode: 200,
       body: JSON.stringify({ message: 'Received' }),
-      headers: { 'Access-Control-Allow-Origin': '*' }
+      headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }
     };
   } catch (err) {
     console.error('Contact error:', err);
     return {
       statusCode: 500,
       body: JSON.stringify({ message: 'Submission failed' }),
-      headers: { 'Access-Control-Allow-Origin': '*' }
+      headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }
     };
   }
 };

--- a/backend/handlers/dashboardAccounting/index.js
+++ b/backend/handlers/dashboardAccounting/index.js
@@ -59,7 +59,7 @@ exports.handler = async (event) => {
 };
 
 function response(statusCode, body) {
-  return { statusCode, headers: { 'Access-Control-Allow-Origin': '*' }, body: JSON.stringify(body) };
+  return { statusCode, headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }, body: JSON.stringify(body) };
 }
 
 function clean(item) {

--- a/backend/handlers/dashboardAnalytics/index.js
+++ b/backend/handlers/dashboardAnalytics/index.js
@@ -31,7 +31,7 @@ exports.handler = async (event) => {
 function response(statusCode, body) {
   return {
     statusCode,
-    headers: { 'Access-Control-Allow-Origin': '*' },
+    headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
     body: JSON.stringify(body)
   };
 }

--- a/backend/handlers/dashboardCampaigns/index.js
+++ b/backend/handlers/dashboardCampaigns/index.js
@@ -35,7 +35,7 @@ exports.handler = async (event) => {
 function response(statusCode, body) {
   return {
     statusCode,
-    headers: { 'Access-Control-Allow-Origin': '*' },
+    headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
     body: JSON.stringify(body)
   };
 }

--- a/backend/handlers/dashboardCatalog/index.js
+++ b/backend/handlers/dashboardCatalog/index.js
@@ -26,7 +26,7 @@ exports.handler = async (event) => {
 };
 
 function response(statusCode, body) {
-  return { statusCode, headers: { 'Access-Control-Allow-Origin': '*' }, body: JSON.stringify(body) };
+  return { statusCode, headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }, body: JSON.stringify(body) };
 }
 
 function clean(item) {

--- a/backend/handlers/dashboardEarnings/index.js
+++ b/backend/handlers/dashboardEarnings/index.js
@@ -26,7 +26,7 @@ exports.handler = async (event) => {
 };
 
 function response(statusCode, body) {
-  return { statusCode, headers: { 'Access-Control-Allow-Origin': '*' }, body: JSON.stringify(body) };
+  return { statusCode, headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }, body: JSON.stringify(body) };
 }
 
 function clean(item) {

--- a/backend/handlers/dashboardSpotify/index.js
+++ b/backend/handlers/dashboardSpotify/index.js
@@ -24,7 +24,7 @@ exports.handler = async (event) => {
 };
 
 function response(statusCode, body) {
-  return { statusCode, headers: { 'Access-Control-Allow-Origin': '*' }, body: JSON.stringify(body) };
+  return { statusCode, headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }, body: JSON.stringify(body) };
 }
 
 function clean(item) {

--- a/backend/handlers/dashboardStatements/index.js
+++ b/backend/handlers/dashboardStatements/index.js
@@ -31,7 +31,7 @@ exports.handler = async (event) => {
 function response(statusCode, body) {
   return {
     statusCode,
-    headers: { 'Access-Control-Allow-Origin': '*' },
+    headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
     body: JSON.stringify(body)
   };
 }

--- a/backend/handlers/dashboardStreams/index.js
+++ b/backend/handlers/dashboardStreams/index.js
@@ -26,7 +26,7 @@ exports.handler = async (event) => {
 };
 
 function response(statusCode, body) {
-  return { statusCode, headers: { 'Access-Control-Allow-Origin': '*' }, body: JSON.stringify(body) };
+  return { statusCode, headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }, body: JSON.stringify(body) };
 }
 
 function clean(item) {

--- a/backend/handlers/dashboardTeam/index.js
+++ b/backend/handlers/dashboardTeam/index.js
@@ -7,7 +7,7 @@ exports.handler = async () => {
     const team = process.env.TEAM_JSON ? JSON.parse(process.env.TEAM_JSON) : defaultTeam;
     return {
       statusCode: 200,
-      headers: { 'Access-Control-Allow-Origin': '*' },
+      headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
       body: JSON.stringify(team)
     };
   } catch (err) {

--- a/backend/handlers/expenseHandler.js
+++ b/backend/handlers/expenseHandler.js
@@ -42,7 +42,7 @@ exports.handler = async (event) => {
 };
 
 function response(statusCode, body) {
-  return { statusCode, headers: { 'Access-Control-Allow-Origin': '*' }, body: JSON.stringify(body) };
+  return { statusCode, headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }, body: JSON.stringify(body) };
 }
 
 function cleanItem(item) {

--- a/backend/handlers/exportAccountingHandler.js
+++ b/backend/handlers/exportAccountingHandler.js
@@ -61,7 +61,7 @@ exports.handler = async (event) => {
 };
 
 function response(statusCode, body) {
-  return { statusCode, headers: { 'Access-Control-Allow-Origin': '*' }, body: JSON.stringify(body) };
+  return { statusCode, headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }, body: JSON.stringify(body) };
 }
 
 function cleanItem(item) {

--- a/backend/handlers/loginHandler/index.js
+++ b/backend/handlers/loginHandler/index.js
@@ -12,7 +12,7 @@ exports.handler = async (event) => {
     return {
       statusCode: 400,
       body: JSON.stringify({ message: 'Missing credentials' }),
-      headers: { 'Access-Control-Allow-Origin': '*' }
+      headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }
     };
   }
 
@@ -36,14 +36,14 @@ exports.handler = async (event) => {
         refreshToken: auth.AuthenticationResult.RefreshToken,
         groups
       }),
-      headers: { 'Access-Control-Allow-Origin': '*' }
+      headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }
     };
   } catch (err) {
     console.error('Cognito auth error', err);
     return {
       statusCode: 401,
       body: JSON.stringify({ message: 'Invalid credentials' }),
-      headers: { 'Access-Control-Allow-Origin': '*' }
+      headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }
     };
   }
 };

--- a/backend/handlers/marketingSpendHandler.js
+++ b/backend/handlers/marketingSpendHandler.js
@@ -38,7 +38,7 @@ exports.handler = async (event) => {
 };
 
 function response(statusCode, body) {
-  return { statusCode, headers: { 'Access-Control-Allow-Origin': '*' }, body: JSON.stringify(body) };
+  return { statusCode, headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }, body: JSON.stringify(body) };
 }
 
 function cleanItem(item) {

--- a/backend/handlers/revenueHandler.js
+++ b/backend/handlers/revenueHandler.js
@@ -44,7 +44,7 @@ exports.handler = async (event) => {
 };
 
 function response(statusCode, body) {
-  return { statusCode, headers: { 'Access-Control-Allow-Origin': '*' }, body: JSON.stringify(body) };
+  return { statusCode, headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }, body: JSON.stringify(body) };
 }
 
 function cleanItem(item) {

--- a/backend/handlers/signinHandler/index.js
+++ b/backend/handlers/signinHandler/index.js
@@ -12,7 +12,7 @@ exports.handler = async (event) => {
     return {
       statusCode: 400,
       body: JSON.stringify({ message: 'Missing credentials' }),
-      headers: { 'Access-Control-Allow-Origin': '*' }
+      headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }
     };
   }
 
@@ -36,14 +36,14 @@ exports.handler = async (event) => {
         refreshToken: auth.AuthenticationResult.RefreshToken,
         groups
       }),
-      headers: { 'Access-Control-Allow-Origin': '*' }
+      headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }
     };
   } catch (err) {
     console.error('Cognito auth error', err);
     return {
       statusCode: 401,
       body: JSON.stringify({ message: 'Invalid credentials' }),
-      headers: { 'Access-Control-Allow-Origin': '*' }
+      headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }
     };
   }
 };

--- a/backend/handlers/spotifyCallbackHandler/index.js
+++ b/backend/handlers/spotifyCallbackHandler/index.js
@@ -44,7 +44,7 @@ exports.handler = async (event) => {
         resolve({
           statusCode: res.statusCode,
           body: JSON.stringify(json),
-          headers: { 'Access-Control-Allow-Origin': '*' }
+          headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }
         });
       });
     });
@@ -53,7 +53,7 @@ exports.handler = async (event) => {
       resolve({
         statusCode: 500,
         body: JSON.stringify({ error: e.message }),
-        headers: { 'Access-Control-Allow-Origin': '*' }
+        headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }
       });
     });
 

--- a/backend/handlers/subscriptionReportHandler.js
+++ b/backend/handlers/subscriptionReportHandler.js
@@ -14,7 +14,7 @@ exports.handler = async () => {
     const avgRetention = calcRetention(records);
     return {
       statusCode: 200,
-      headers: { 'Access-Control-Allow-Origin': '*' },
+      headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
       body: JSON.stringify({ totalSubscribers, monthlyRevenue, avgRetention })
     };
   } catch (err) {


### PR DESCRIPTION
## Summary
- ensure all backend handlers return `Content-Type` header along with CORS header
- keep existing CSV response behaviour for exportAccounting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68868c8c973483248856b2907638cef4