### PR TITLE
Fix marketing panel fetch URL

### DIFF
--- a/frontend/src/components/MarketingPanel.jsx
+++ b/frontend/src/components/MarketingPanel.jsx
@@ -1,10 +1,14 @@
 import React, { useEffect, useState } from 'react';
 
+const API_BASE =
+  process.env.REACT_APP_API_URL ||
+  'https://2h2oj7u446.execute-api.eu-central-1.amazonaws.com/prod';
+
 export default function MarketingPanel({ user }) {
   const [buzz, setBuzz] = useState('');
 
   useEffect(() => {
-    fetch('/industry_buzz.txt')
+    fetch(`${API_BASE}/industry_buzz.txt`)
       .then(async (res) => {
         if (!res.ok) {
           return '';


### PR DESCRIPTION
## Summary
- fetch marketing data from API URL in MarketingPanel

## Testing
- `npm run build` in `frontend`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68868e67a4ac8324ade7e04a34d69917