### PR TITLE
Add reusable CORS helper

### DIFF
--- a/backend/handlers/dashboardAnalytics/index.js
+++ b/backend/handlers/dashboardAnalytics/index.js
@@ -1,4 +1,5 @@
 const { DynamoDBClient, QueryCommand } = require('@aws-sdk/client-dynamodb');
+const { headers: defaultHeaders, response } = require('../../../lambda/shared/cors-headers');
 
 const REGION = process.env.AWS_REGION || 'eu-central-1';
 const TABLE = process.env.DYNAMO_TABLE_ANALYTICS || 'WeeklyArtistStats';
@@ -6,6 +7,9 @@ const ddb = new DynamoDBClient({ region: REGION });
 const DEFAULT_STATS = [{ week_start: '2025-01-01', spotify_streams: 0, youtube_views: 0 }];
 
 exports.handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 200, headers: defaultHeaders, body: '' };
+  }
   try {
     const qs = event.queryStringParameters || {};
     if (!qs.artist_id) {
@@ -27,14 +31,6 @@ exports.handler = async (event) => {
     return response(500, { message: 'Internal Server Error' });
   }
 };
-
-function response(statusCode, body) {
-  return {
-    statusCode,
-    headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
-    body: JSON.stringify(body)
-  };
-}
 
 function clean(item) {
   const obj = {};

--- a/backend/handlers/dashboardSpotify/index.js
+++ b/backend/handlers/dashboardSpotify/index.js
@@ -1,10 +1,14 @@
 const { DynamoDBClient, QueryCommand } = require('@aws-sdk/client-dynamodb');
+const { headers: defaultHeaders, response } = require('../../../lambda/shared/cors-headers');
 
 const REGION = process.env.AWS_REGION || 'eu-central-1';
 const TABLE = process.env.SPOTIFY_TABLE || 'SpotifyArtistData';
 const ddb = new DynamoDBClient({ region: REGION });
 
 exports.handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 200, headers: defaultHeaders, body: '' };
+  }
   try {
     const qs = event.queryStringParameters || {};
     if (!qs.artist_id) return response(400, { message: 'artist_id required' });
@@ -22,10 +26,6 @@ exports.handler = async (event) => {
     return response(500, { message: 'Internal Server Error' });
   }
 };
-
-function response(statusCode, body) {
-  return { statusCode, headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }, body: JSON.stringify(body) };
-}
 
 function clean(item) {
   const obj = {};

--- a/lambda/shared/cors-headers.js
+++ b/lambda/shared/cors-headers.js
@@ -1,30 +1,32 @@
 const headers = {
     'Access-Control-Allow-Origin': 'https://decodedmusic.com',
     'Access-Control-Allow-Headers': 'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token',
-    'Access-Control-Allow-Methods': 'GET,POST,OPTIONS,PUT,DELETE'
+    'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+    'Content-Type': 'application/json'
 };
 
-function successResponse(data) {
-    return {
-        statusCode: 200,
-        headers,
-        body: JSON.stringify(data)
-    };
-}
-
-function errorResponse(error, statusCode = 500) {
+function response(statusCode, body) {
     return {
         statusCode,
         headers,
-        body: JSON.stringify({
-            error: error.message || error,
-            timestamp: new Date().toISOString()
-        })
+        body: JSON.stringify(body)
     };
+}
+
+function successResponse(data) {
+    return response(200, data);
+}
+
+function errorResponse(error, statusCode = 500) {
+    return response(statusCode, {
+        error: error.message || error,
+        timestamp: new Date().toISOString()
+    });
 }
 
 module.exports = {
     headers,
+    response,
     successResponse,
     errorResponse
 };

--- a/tests/cors-headers.test.js
+++ b/tests/cors-headers.test.js
@@ -1,11 +1,17 @@
 const assert = require('assert');
-const { headers, successResponse, errorResponse } = require('../lambda/shared/cors-headers');
+const { headers, response, successResponse, errorResponse } = require('../lambda/shared/cors-headers');
 
 const data = { ok: true };
 const success = successResponse(data);
 assert.strictEqual(success.statusCode, 200);
 assert.deepStrictEqual(success.headers, headers);
 assert.strictEqual(success.body, JSON.stringify(data));
+assert.strictEqual(headers['Content-Type'], 'application/json');
+
+const generic = response(201, { created: true });
+assert.strictEqual(generic.statusCode, 201);
+assert.deepStrictEqual(generic.headers, headers);
+assert.strictEqual(generic.body, JSON.stringify({ created: true }));
 
 const err = new Error('oops');
 const failure = errorResponse(err, 400);


### PR DESCRIPTION
## Summary
- add Content-Type to `cors-headers` helper and expose new `response` util
- extend unit test for helper
- apply helper to dashboard Spotify and Analytics lambdas

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6886922b8a108324a468041304189508