### PR TITLE
Fix CORS headers for growth-dashboard lambda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ decoded-mirror.bfg-report/
 # Additional build artifacts
 .aws-sam/
 lambda/growth-dashboard-lambda/
+!lambda/growth-dashboard-lambda/lambda_function.py
 archives/
 archive/
 frontend/src/fix-artistid/

--- a/lambda/growth-dashboard-lambda/lambda_function.py
+++ b/lambda/growth-dashboard-lambda/lambda_function.py
@@ -4,7 +4,8 @@ import subprocess
 CORS_HEADERS = {
     "Access-Control-Allow-Origin": "https://decodedmusic.com",
     "Access-Control-Allow-Headers": "Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token",
-    "Access-Control-Allow-Methods": "GET,POST,OPTIONS"
+    "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+    "Content-Type": "application/json"
 }
 
 
@@ -26,7 +27,7 @@ def lambda_handler(event, context):
         ])
         return {
             "statusCode": 200,
-            "headers": {**CORS_HEADERS, "Content-Type": "application/json"},
+            "headers": CORS_HEADERS,
             "body": result.decode("utf-8")
         }
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
## Summary
- ensure growth-dashboard lambda always sets `Content-Type` in CORS headers
- unignore lambda file so updates can be tracked

## Testing
- `npm test`
- `pytest` *(fails: AttributeError: module 'os' has no attribute 'add_dll_directory')*

------
https://chatgpt.com/codex/tasks/task_b_6886970f6fac8324babdf1105bb6f525