### PR TITLE
Fix frontend CORS request headers

### DIFF
--- a/frontend/src/api/apiconfig.js
+++ b/frontend/src/api/apiconfig.js
@@ -19,7 +19,6 @@ const API_ENDPOINTS = {
 
 const DEFAULT_HEADERS = {
   'Content-Type': 'application/json',
-  'Access-Control-Allow-Origin': '*',
 };
 
 function getToken() {


### PR DESCRIPTION
## Summary
- remove `Access-Control-Allow-Origin` from request headers used by `fetch`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6886e468db488324b71bd975f8d4a95b