### PR TITLE
Fix login route to use Cognito auth

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,7 +3,7 @@ import { Routes, Route, Navigate, Link } from 'react-router-dom';
 
 import LandingPage from './components/LandingPage.js';
 import Dashboard from './components/Dashboard.js';
-import CognitoLogin from './components/CognitoLogin.js';
+import Login from './components/Login.jsx';
 import MarketingPanel from './components/MarketingPanel.jsx';
 import CatalogPanel from './components/catalog/CatalogPanel.jsx';
 import AnalyticsPanel from './components/AnalyticsPanel.jsx';
@@ -56,7 +56,7 @@ function App() {
         <Route
           path="/login"
           element={
-            isAuthenticated ? <Navigate to="/dashboard" replace /> : <CognitoLogin />
+            isAuthenticated ? <Navigate to="/dashboard" replace /> : <Login />
           }
         />
         <Route

--- a/frontend/src/components/CognitoLogin.js
+++ b/frontend/src/components/CognitoLogin.js
@@ -114,7 +114,7 @@ const CognitoLogin = () => {
                 )}
                 
                 <div style={{ marginTop: '2rem', textAlign: 'center', fontSize: '0.9rem', color: '#718096' }}>
-                    <p>Demo Mode: Use any email/password to access dashboard</p>
+                    <p>Sign in with your Cognito credentials</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- switch `/login` to use the real Cognito redirect component
- clarify login message in the old Cognito login form

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6886e703e43c8324b727804eab923e9e