### PR TITLE
Add CORS headers to backend lambdas

### DIFF
--- a/backend/dashboardSpotify/index.js
+++ b/backend/dashboardSpotify/index.js
@@ -1,13 +1,18 @@
-const { headers } = require('../../lambda/shared/cors-headers');
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'OPTIONS,POST,GET',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Content-Type': 'application/json'
+};
 
 exports.handler = async (event) => {
   if (event.httpMethod === 'OPTIONS') {
-    return { statusCode: 200, headers, body: '' };
+    return { statusCode: 200, headers: corsHeaders, body: '' };
   }
   console.log("Spotify handler triggered");
   return {
     statusCode: 200,
-    headers,
+    headers: corsHeaders,
     body: JSON.stringify({ message: "Spotify endpoint working!" }),
   };
 };

--- a/backend/handlers/analytics-lambda/handler.js
+++ b/backend/handlers/analytics-lambda/handler.js
@@ -1,12 +1,22 @@
-const { headers } = require('../../../lambda/shared/cors-headers');
-
 exports.handler = async (event) => {
+  const corsHeaders = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'OPTIONS,POST,GET',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Content-Type': 'application/json'
+  };
+
   if (event.httpMethod === 'OPTIONS') {
-    return { statusCode: 200, headers, body: '' };
+    return {
+      statusCode: 200,
+      headers: corsHeaders,
+      body: ''
+    };
   }
+
   return {
     statusCode: 200,
-    headers,
+    headers: corsHeaders,
     body: JSON.stringify({ message: 'Analytics placeholder' })
   };
 };

--- a/backend/handlers/dashboardSpotify/index.js
+++ b/backend/handlers/dashboardSpotify/index.js
@@ -1,13 +1,27 @@
 const { DynamoDBClient, QueryCommand } = require('@aws-sdk/client-dynamodb');
-const { headers: defaultHeaders, response } = require('../../../lambda/shared/cors-headers');
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'OPTIONS,POST,GET',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Content-Type': 'application/json'
+};
 
 const REGION = process.env.AWS_REGION || 'eu-central-1';
 const TABLE = process.env.SPOTIFY_TABLE || 'SpotifyArtistData';
 const ddb = new DynamoDBClient({ region: REGION });
 
+function response(statusCode, body) {
+  return {
+    statusCode,
+    headers: corsHeaders,
+    body: JSON.stringify(body)
+  };
+}
+
 exports.handler = async (event) => {
   if (event.httpMethod === 'OPTIONS') {
-    return { statusCode: 200, headers: defaultHeaders, body: '' };
+    return { statusCode: 200, headers: corsHeaders, body: '' };
   }
   try {
     const qs = event.queryStringParameters || {};

--- a/backend/handlers/marketingSpendHandler.js
+++ b/backend/handlers/marketingSpendHandler.js
@@ -3,8 +3,21 @@ const { DynamoDBClient, PutItemCommand, QueryCommand } = require('@aws-sdk/clien
 const REGION = process.env.AWS_REGION || 'eu-central-1';
 const TABLE = process.env.SPEND_TABLE || 'MarketingSpend';
 const ddb = new DynamoDBClient({ region: REGION });
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'OPTIONS,POST,GET',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Content-Type': 'application/json'
+};
 
 exports.handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') {
+    return {
+      statusCode: 200,
+      headers: corsHeaders,
+      body: ''
+    };
+  }
   try {
     if (event.httpMethod === 'POST') {
       const body = JSON.parse(event.body || '{}');
@@ -38,7 +51,11 @@ exports.handler = async (event) => {
 };
 
 function response(statusCode, body) {
-  return { statusCode, headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }, body: JSON.stringify(body) };
+  return {
+    statusCode,
+    headers: corsHeaders,
+    body: JSON.stringify(body)
+  };
 }
 
 function cleanItem(item) {

--- a/backend/handlers/spotifyAuthHandler/spotifyAuthHandler/index.js
+++ b/backend/handlers/spotifyAuthHandler/spotifyAuthHandler/index.js
@@ -1,17 +1,22 @@
 const querystring = require("querystring");
-const { headers } = require('../../../../lambda/shared/cors-headers');
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'OPTIONS,POST,GET',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Content-Type': 'application/json'
+};
 
 const CLIENT_ID = process.env.SPOTIFY_CLIENT_ID;
 const REDIRECT_URI = process.env.SPOTIFY_REDIRECT_URI;
 
 exports.handler = async (event = {}) => {
   if (event.httpMethod === 'OPTIONS') {
-    return { statusCode: 200, headers, body: '' };
+    return { statusCode: 200, headers: corsHeaders, body: '' };
   }
   if (!CLIENT_ID || !REDIRECT_URI) {
     return {
       statusCode: 500,
-      headers,
+      headers: corsHeaders,
       body: JSON.stringify({ error: "Missing CLIENT_ID or REDIRECT_URI in environment variables." }),
     };
   }
@@ -25,6 +30,6 @@ exports.handler = async (event = {}) => {
 
   return {
     statusCode: 302,
-    headers: { ...headers, Location: authURL },
+    headers: { ...corsHeaders, Location: authURL },
   };
 };

--- a/backend/handlers/spotifyCallbackHandler/index.js
+++ b/backend/handlers/spotifyCallbackHandler/index.js
@@ -2,6 +2,21 @@ const https = require('https');
 const querystring = require('querystring');
 
 exports.handler = async (event) => {
+  const corsHeaders = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'OPTIONS,POST,GET',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Content-Type': 'application/json'
+  };
+
+  if (event.httpMethod === 'OPTIONS') {
+    return {
+      statusCode: 200,
+      headers: corsHeaders,
+      body: ''
+    };
+  }
+
   const code = event.queryStringParameters?.code;
   if (!code) {
     return { statusCode: 400, body: 'Missing code' };
@@ -44,7 +59,7 @@ exports.handler = async (event) => {
         resolve({
           statusCode: res.statusCode,
           body: JSON.stringify(json),
-          headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }
+          headers: corsHeaders
         });
       });
     });
@@ -53,7 +68,7 @@ exports.handler = async (event) => {
       resolve({
         statusCode: 500,
         body: JSON.stringify({ error: e.message }),
-        headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }
+        headers: corsHeaders
       });
     });
 


### PR DESCRIPTION
## Summary
- update analytics lambda to handle CORS
- add CORS logic to Spotify lambdas
- enable OPTIONS handling in marketing spend lambda

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_b_6886e83e427483249d123540bf17d50a