### PR TITLE
Update API Gateway methods to ANY

### DIFF
--- a/infra/cloudformation/API-Gateway-Complete-REST-API.yml
+++ b/infra/cloudformation/API-Gateway-Complete-REST-API.yml
@@ -47,7 +47,7 @@ Resources:
     Properties:
       RestApiId: !Ref DecodedMusicAPI
       ResourceId: !Ref AuthResource
-      HttpMethod: POST
+      HttpMethod: ANY
       AuthorizationType: NONE
       Integration:
         Type: AWS_PROXY
@@ -69,7 +69,7 @@ Resources:
     Properties:
       RestApiId: !Ref DecodedMusicAPI
       ResourceId: !Ref AuthResource
-      HttpMethod: PUT
+      HttpMethod: ANY
       AuthorizationType: NONE
       Integration:
         Type: AWS_PROXY
@@ -99,7 +99,7 @@ Resources:
     Properties:
       RestApiId: !Ref DecodedMusicAPI
       ResourceId: !Ref SubscriptionResource
-      HttpMethod: POST
+      HttpMethod: ANY
       AuthorizationType: NONE
       Integration:
         Type: AWS_PROXY

--- a/infra/cloudformation/catalog-api.yml
+++ b/infra/cloudformation/catalog-api.yml
@@ -43,8 +43,8 @@ Resources:
       Handler: index.handler
       Role: !GetAtt CatalogLambdaRole.Arn
       Code:
-        S3Bucket: decodedmusic.com
-        S3Key: lambda/catalog-handler.zip
+        S3Bucket: decodedmusic-lambda-code
+        S3Key: prod-catalog-handler.zip
       Environment:
         Variables:
           CATALOG_TABLE: !Sub '${EnvName}-DecodedCatalog'
@@ -75,7 +75,7 @@ Resources:
     Type: AWS::ApiGateway::Method
     Properties:
       AuthorizationType: NONE
-      HttpMethod: GET
+      HttpMethod: ANY
       ResourceId: !Ref CatalogResource
       RestApiId: !Ref ApiGateway
       Integration:
@@ -86,7 +86,7 @@ Resources:
     Type: AWS::ApiGateway::Method
     Properties:
       AuthorizationType: NONE
-      HttpMethod: GET
+      HttpMethod: ANY
       ResourceId: !Ref CatalogIdResource
       RestApiId: !Ref ApiGateway
       Integration:
@@ -99,7 +99,7 @@ Resources:
       FunctionName: !Ref CatalogLambda
       Action: lambda:InvokeFunction
       Principal: apigateway.amazonaws.com
-      SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ApiGateway}/*/GET/api/catalog*'
+      SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ApiGateway}/*/*/api/catalog*'
 Outputs:
   ApiUrl:
     Value: !Sub 'https://${ApiGateway}.execute-api.${AWS::Region}.amazonaws.com/prod/api/catalog'

--- a/infra/cloudformation/contactApi.yml
+++ b/infra/cloudformation/contactApi.yml
@@ -27,13 +27,13 @@ Resources:
   ContactLambdaFunction:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: DecodedContactHandler
+      FunctionName: prod-decodedContactHandler
       Runtime: nodejs18.x
       Role: !GetAtt LambdaExecutionRole.Arn
       Handler: index.handler
       Code:
-        S3Bucket: decodedmusic.com
-        S3Key: lambda/contact-handler.zip
+        S3Bucket: decodedmusic-lambda-code
+        S3Key: prod-decodedContactHandler.zip
 
   ContactApi:
     Type: AWS::ApiGateway::RestApi
@@ -51,7 +51,7 @@ Resources:
     Type: AWS::ApiGateway::Method
     Properties:
       AuthorizationType: NONE
-      HttpMethod: POST
+      HttpMethod: ANY
       ResourceId: !Ref ContactResource
       RestApiId: !Ref ContactApi
       Integration:
@@ -67,4 +67,4 @@ Resources:
       FunctionName: !GetAtt ContactLambdaFunction.Arn
       Action: lambda:InvokeFunction
       Principal: apigateway.amazonaws.com
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ContactApi}/*/POST/contact
+      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ContactApi}/*/*/contact

--- a/infra/cloudformation/loginApi.yml
+++ b/infra/cloudformation/loginApi.yml
@@ -3,13 +3,13 @@ Resources:
   LoginLambdaFunction:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: DecodedLoginHandler
+      FunctionName: prod-decodedLoginHandler
       Runtime: nodejs18.x
       Role: !GetAtt LambdaExecutionRole.Arn
       Handler: index.handler
       Code:
-        S3Bucket: decodedmusic.com
-        S3Key: lambda/login-handler.zip
+        S3Bucket: decodedmusic-lambda-code
+        S3Key: prod-decodedLoginHandler.zip
 
   LoginApi:
     Type: AWS::ApiGateway::RestApi
@@ -34,7 +34,7 @@ Resources:
     Type: AWS::ApiGateway::Method
     Properties:
       AuthorizationType: NONE
-      HttpMethod: POST
+      HttpMethod: ANY
       ResourceId: !Ref LoginResource
       RestApiId: !Ref LoginApi
       Integration:
@@ -50,4 +50,4 @@ Resources:
       FunctionName: !GetAtt LoginLambdaFunction.Arn
       Action: lambda:InvokeFunction
       Principal: apigateway.amazonaws.com
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${LoginApi}/*/POST/auth/login
+      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${LoginApi}/*/*/auth/login

--- a/infra/cloudformation/signinApi.yml
+++ b/infra/cloudformation/signinApi.yml
@@ -3,13 +3,13 @@ Resources:
   SigninLambdaFunction:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: DecodedSigninHandler
+      FunctionName: prod-decodedSigninHandler
       Runtime: nodejs18.x
       Role: !GetAtt LambdaExecutionRole.Arn
       Handler: index.handler
       Code:
-        S3Bucket: decodedmusic.com
-        S3Key: lambda/signin-handler.zip
+        S3Bucket: decodedmusic-lambda-code
+        S3Key: prod-decodedSigninHandler.zip
 
   SigninApi:
     Type: AWS::ApiGateway::RestApi
@@ -34,7 +34,7 @@ Resources:
     Type: AWS::ApiGateway::Method
     Properties:
       AuthorizationType: NONE
-      HttpMethod: POST
+      HttpMethod: ANY
       ResourceId: !Ref SigninResource
       RestApiId: !Ref SigninApi
       Integration:
@@ -50,4 +50,4 @@ Resources:
       FunctionName: !GetAtt SigninLambdaFunction.Arn
       Action: lambda:InvokeFunction
       Principal: apigateway.amazonaws.com
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${SigninApi}/*/POST/auth/signin
+      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${SigninApi}/*/*/auth/signin

--- a/infra/cloudformation/signupApi.yml
+++ b/infra/cloudformation/signupApi.yml
@@ -3,13 +3,13 @@ Resources:
   SignupLambdaFunction:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: DecodedSignupHandler
+      FunctionName: prod-decodedSignupHandler
       Runtime: nodejs18.x
       Role: !GetAtt LambdaExecutionRole.Arn
       Handler: index.handler
       Code:
-        S3Bucket: decodedmusic.com
-        S3Key: lambda/signup-handler.zip
+        S3Bucket: decodedmusic-lambda-code
+        S3Key: prod-decodedSignupHandler.zip
 
   SignupApi:
     Type: AWS::ApiGateway::RestApi
@@ -27,7 +27,7 @@ Resources:
     Type: AWS::ApiGateway::Method
     Properties:
       AuthorizationType: NONE
-      HttpMethod: POST
+      HttpMethod: ANY
       ResourceId: !Ref SignupResource
       RestApiId: !Ref SignupApi
       Integration:
@@ -43,4 +43,4 @@ Resources:
       FunctionName: !GetAtt SignupLambdaFunction.Arn
       Action: lambda:InvokeFunction
       Principal: apigateway.amazonaws.com
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${SignupApi}/*/POST/signup
+      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${SignupApi}/*/*/signup

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -150,7 +150,7 @@ Resources:
           Properties:
             RestApiId: !Ref DecodedApi
             Path: /catalog
-            Method: GET
+            Method: ANY
 
   # DashboardStreamsFunction -> Role: arn:aws:iam::396913703024:role/decoded-genai-stack-backend-DashboardLambdaRole-YkDbqxxNlaMR, S3Key: prod-dashboardStreams.zip, Env: DYNAMO_TABLE_STREAMS
   DashboardStreamsFunction:
@@ -172,7 +172,7 @@ Resources:
           Properties:
             RestApiId: !Ref DecodedApi
             Path: /dashboard/streams
-            Method: GET
+            Method: ANY
 
   # DashboardEarningsFunction -> S3Key: prod-dashboardEarnings.zip, Env: DYNAMO_TABLE_EARNINGS
   DashboardEarningsFunction:
@@ -193,7 +193,7 @@ Resources:
           Properties:
             RestApiId: !Ref DecodedApi
             Path: /dashboard/earnings
-            Method: GET
+            Method: ANY
 
   # DashboardCatalogFunction -> S3Key: prod-dashboardCatalog.zip, Env: DYNAMO_TABLE_CATALOG
   DashboardCatalogFunction:
@@ -214,7 +214,7 @@ Resources:
           Properties:
             RestApiId: !Ref DecodedApi
             Path: /dashboard/catalog
-            Method: GET
+            Method: ANY
 
   # DashboardAnalyticsFunction -> S3Key: prod-dashboardAnalytics.zip, Env: DYNAMO_TABLE_ANALYTICS
   DashboardAnalyticsFunction:
@@ -235,7 +235,7 @@ Resources:
           Properties:
             RestApiId: !Ref DecodedApi
             Path: /dashboard/analytics
-            Method: GET
+            Method: ANY
 
   # DashboardStatementsFunction -> S3Key: prod-dashboardStatements.zip, Env: DYNAMO_TABLE_STATEMENTS
   DashboardStatementsFunction:
@@ -256,7 +256,7 @@ Resources:
           Properties:
             RestApiId: !Ref DecodedApi
             Path: /dashboard/statements
-            Method: GET
+            Method: ANY
 
   # DashboardCampaignsFunction -> S3Key: prod-dashboardCampaigns.zip, Env: SPEND_TABLE
   DashboardCampaignsFunction:
@@ -277,7 +277,7 @@ Resources:
           Properties:
             RestApiId: !Ref DecodedApi
             Path: /dashboard/campaigns
-            Method: GET
+            Method: ANY
 
   # DashboardSpotifyFunction -> S3Key: prod-dashboardSpotify.zip, Env: SPOTIFY_TABLE
   DashboardSpotifyFunction:
@@ -298,7 +298,7 @@ Resources:
           Properties:
             RestApiId: !Ref DecodedApi
             Path: /dashboard/spotify
-            Method: GET
+            Method: ANY
 
   # DashboardAccountingFunction -> S3Key: prod-dashboardAccounting.zip, Env: REVENUE_TABLE, EXPENSE_TABLE
   DashboardAccountingFunction:
@@ -320,7 +320,7 @@ Resources:
           Properties:
             RestApiId: !Ref DecodedApi
             Path: /dashboard/accounting
-            Method: GET
+            Method: ANY
 
   # DashboardTeamFunction -> S3Key: prod-dashboardTeam.zip, Env: TEAM_JSON
   DashboardTeamFunction:
@@ -341,7 +341,7 @@ Resources:
           Properties:
             RestApiId: !Ref DecodedApi
             Path: /dashboard/team
-            Method: GET
+            Method: ANY
 
 # === Marketing Functions ===
 # See cloudformation/marketing-hub.yml for marketing Lambdas


### PR DESCRIPTION
## Summary
- update CloudFormation stacks to use `HttpMethod: ANY`
- rename Lambda functions with `prod-` prefix and adjust S3 locations
- update API Gateway permissions for unified method mapping

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6887f1953bbc83249aca424ff3835371