### PR TITLE
Fix login redirect

### DIFF
--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-const loginUrl = "https://auth.decodedmusic.com/login?client_id=5pb29tja8gkqm3jb43oimd5qjt&response_type=code&scope=openid+email+profile&redirect_uri=https://decodedmusic.com/dashboard";
+const loginUrl =
+  "https://auth.decodedmusic.com/login?client_id=5pb29tja8gkqm3jb43oimd5qjt&response_type=token&scope=openid+email+profile&redirect_uri=https://decodedmusic.com/dashboard";
 
 const Login = () => {
   const redirectToCognito = () => {

--- a/frontend/src/context/AuthContext.js
+++ b/frontend/src/context/AuthContext.js
@@ -37,6 +37,10 @@ export function AuthProvider({ children }) {
     }
 
     checkAuthStatus();
+
+    // Check session validity every 5 minutes instead of 30 seconds
+    const interval = setInterval(checkAuthStatus, 300000);
+    return () => clearInterval(interval);
   }, []);
 
   const signIn = async (email, password) => {


### PR DESCRIPTION
## Summary
- switch login redirect to token response type to match token parsing
- periodically verify session validity in AuthContext
- extend session check interval to 5 minutes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6888222e009c8324ae4ce2792e95050f