### PR TITLE
Fix login loop from session checks

### DIFF
--- a/frontend/src/context/AuthContext.js
+++ b/frontend/src/context/AuthContext.js
@@ -17,6 +17,10 @@ export function AuthProvider({ children }) {
           setUser(result.user);
           setUsername(result.username);
           setIsAuthenticated(true);
+        } else if (result.error === 'Session invalid') {
+          console.warn('Session expired or invalid. Logging out...');
+          await cognitoAuthService.signOut();
+          window.location.href = '/login';
         }
       } catch (error) {
         console.error('Error checking authentication status:', error);
@@ -39,9 +43,11 @@ export function AuthProvider({ children }) {
 
   const signOut = async () => {
     await cognitoAuthService.signOut();
+    localStorage.clear();
     setUser(null);
     setUsername('');
     setIsAuthenticated(false);
+    window.location.href = '/login';
   };
 
   return (

--- a/frontend/src/services/CognitoAuthService.js
+++ b/frontend/src/services/CognitoAuthService.js
@@ -46,17 +46,17 @@ class CognitoAuthService {
         });
     }
 
-    async getCurrentUser() {
+  async getCurrentUser() {
         const currentUser = userPool.getCurrentUser();
 
         if (!currentUser) {
             return { success: false, user: null };
         }
 
-        return new Promise((resolve, reject) => {
+        return new Promise((resolve) => {
             currentUser.getSession((err, session) => {
-                if (err) {
-                    reject({ success: false, error: err.message });
+                if (err || !session?.isValid()) {
+                    resolve({ success: false, error: err ? err.message : 'Session invalid' });
                 } else {
                     resolve({
                         success: true,


### PR DESCRIPTION
## Summary
- prevent automatic logout when no Cognito user exists
- only redirect on truly invalid sessions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68881d1a0fc08324884b44c5d336d13c