### PR TITLE
Fix analytics JSON parsing

### DIFF
--- a/frontend/src/components/AnalyticsPanel.jsx
+++ b/frontend/src/components/AnalyticsPanel.jsx
@@ -10,8 +10,7 @@ export default function AnalyticsPanel({ user }) {
   useEffect(() => {
     async function fetchAnalytics() {
       try {
-        const output = await runGrowthDashboard([`--artistId=${artistId}`]);
-        const data = JSON.parse(output);
+        const data = await runGrowthDashboard([`--artistId=${artistId}`]);
         setAnalyticsData(data);
       } catch (err) {
         setError(err.message || 'Error fetching analytics data');

--- a/frontend/src/scripts/growth-dashboard-wrapper.js
+++ b/frontend/src/scripts/growth-dashboard-wrapper.js
@@ -1,9 +1,17 @@
 // Removed 'path' module and Python script path references
 export async function runGrowthDashboard(args) {
   const artistId = args?.[0]?.split('=')[1];
-  const response = await fetch(`${process.env.REACT_APP_API_BASE}/analytics?artistId=${artistId}`);
+  const response = await fetch(
+    `${process.env.REACT_APP_API_BASE}/analytics?artistId=${artistId}`
+  );
   if (!response.ok) {
     throw new Error('Failed to fetch analytics');
   }
-  return await response.text(); // Returns JSON string
+
+  try {
+    return await response.json();
+  } catch (err) {
+    const text = await response.text();
+    throw new Error(`Invalid JSON response: ${text}`);
+  }
 }


### PR DESCRIPTION
## Summary
- return JSON directly from growth dashboard fetch wrapper
- remove manual JSON.parse in AnalyticsPanel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6888321161408324b796ec36d8182a14