### PR TITLE
Fix Spotify dashboard fetch

### DIFF
--- a/frontend/src/api/dashboard.js
+++ b/frontend/src/api/dashboard.js
@@ -63,12 +63,10 @@ export const DashboardAPI = {
       body: JSON.stringify(payload),
     }),
 
-  getSpotifyData: (payload) =>
-    fetchWithAuth(
-      process.env.REACT_APP_ENHANCED_SPOTIFY_API_URL || `${API_BASE}/spotify`,
-      {
-        method: 'POST',
-        body: JSON.stringify(payload),
-      }
-    ),
+  getSpotifyData: ({ artistId }) => {
+    const base =
+      process.env.REACT_APP_ENHANCED_SPOTIFY_API_URL || `${API_BASE}/spotify`;
+    const url = `${base}?artist_id=${encodeURIComponent(artistId)}`;
+    return fetchWithAuth(url);
+  },
 };


### PR DESCRIPTION
## Summary
- adjust `DashboardAPI.getSpotifyData` to use GET query string instead of POST body

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68883e6e02b08324a709c2b1b5ebbd2c