### PR TITLE
Add deploy test for spotifyArtistFetcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "start": "npm start --prefix frontend",
     "build": "npm run build --prefix frontend",
-    "test": "node tests/cors-headers.test.js",
+    "test": "node tests/cors-headers.test.js && node tests/deploy-spotifyArtistFetcher.test.js",
     "schedule": "node scripts/automationScheduler.js"
   },
   "dependencies": {

--- a/tests/deploy-spotifyArtistFetcher.test.js
+++ b/tests/deploy-spotifyArtistFetcher.test.js
@@ -1,0 +1,25 @@
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+
+if (!process.env.AWS_ACCESS_KEY_ID) {
+  console.log('AWS credentials not configured; skipping deploy-spotifyArtistFetcher tests');
+  process.exit(0);
+}
+
+function run(cmd, args) {
+  const res = spawnSync(cmd, args, { stdio: 'inherit' });
+  assert.strictEqual(res.status, 0, `Command failed: ${cmd} ${args.join(' ')}`);
+}
+
+// Create zip package
+run('zip', ['-r', 'backend/spotifyArtistFetcher.zip', 'backend/handlers/spotifyArtistFetcher']);
+assert.ok(fs.existsSync('backend/spotifyArtistFetcher.zip'), 'Zip file not created');
+
+// Upload to S3
+run('aws', ['s3', 'cp', 'backend/spotifyArtistFetcher.zip', 's3://decodedmusic-lambda-code/', '--region', 'eu-central-1']);
+
+// Update Lambda function
+run('aws', ['lambda', 'update-function-code', '--function-name', 'prod-spotifyArtistFetcher', '--s3-bucket', 'decodedmusic-lambda-code', '--s3-key', 'spotifyArtistFetcher.zip', '--region', 'eu-central-1']);
+
+console.log('deploy-spotifyArtistFetcher tests passed');


### PR DESCRIPTION
## Summary
- add a test that uploads and deploys the spotifyArtistFetcher lambda
- run this new test from the npm test script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68892828fb5c8324985bb4a422326314