### PR TITLE
Refactor lambda folder

### DIFF
--- a/lambda/growthDashboard/growth-dashboard.py
+++ b/lambda/growthDashboard/growth-dashboard.py
@@ -1,0 +1,60 @@
+import boto3
+import json
+from datetime import datetime, timedelta
+import statistics
+import sys
+
+# Configuration - Updated for consistency
+DYNAMO_GROWTH_TABLE = 'prod-GrowthMetrics-decodedmusic-backend'
+DYNAMO_INSIGHTS_TABLE = 'prod-SpotifyInsights-decodedmusic-backend'
+DYNAMO_CATALOG_TABLE = 'prod-DecodedCatalog-decodedmusic-backend'
+SPOTIFY_ARTIST_ID = '293x3NAIGPR4RCJrFkzs0P'  # Spotify Artist ID
+CATALOG_ARTIST_ID = 'ruedevivre'  # Programmatic identifier for DynamoDB queries
+ARTIST_NAME = 'Rue De Vivre'  # Display name for UI and logs
+
+dynamodb = boto3.resource('dynamodb')
+
+def get_growth_history(artist_id, days_back=30):
+    """Get growth metrics history for a specific artist"""
+    try:
+        growth_table = dynamodb.Table(DYNAMO_GROWTH_TABLE)
+        
+        cutoff_date = (datetime.utcnow() - timedelta(days=days_back)).strftime('%Y-%m-%d')
+        
+        response = growth_table.query(
+            IndexName='ArtistDateIndex',
+            KeyConditionExpression='artistId = :aid AND #date > :cutoff',
+            ExpressionAttributeNames={'#date': 'date'},
+            ExpressionAttributeValues={
+                ':aid': artist_id,  # Use the dynamic artist_id
+                ':cutoff': cutoff_date
+            }
+        )
+        
+        return sorted(response['Items'], key=lambda x: x['date'])
+        
+    except Exception as e:
+        print(f"❌ Error getting growth history: {e}")
+        return []
+
+def run(artist_id):
+    # Replace with your actual analytics logic
+    result = {
+        "artistId": artist_id,
+        "streams": 1732,
+        "subscribers": 258,
+        "growthRate": "7.2%"
+    }
+    return result
+
+if __name__ == "__main__":
+    artist_id = None
+    for arg in sys.argv:
+        if arg.startswith("--artistId="):
+            artist_id = arg.split("=")[1]
+
+    if artist_id:
+        print(json.dumps(run(artist_id)))
+    else:
+        print(json.dumps({"error": "Missing artistId"}))
+        sys.exit(1)

--- a/lambda/growthDashboard/index.js
+++ b/lambda/growthDashboard/index.js
@@ -1,0 +1,31 @@
+const { spawnSync } = require('child_process');
+const path = require('path');
+
+const headers = {
+  'Access-Control-Allow-Origin': 'https://decodedmusic.com',
+  'Access-Control-Allow-Headers': 'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token',
+  'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+  'Content-Type': 'application/json'
+};
+
+exports.handler = async (event = {}) => {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 200, headers, body: '' };
+  }
+
+  const artistId = event.queryStringParameters?.artistId || '';
+  if (!artistId) {
+    return { statusCode: 400, headers, body: JSON.stringify({ error: 'artistId is required' }) };
+  }
+
+  try {
+    const script = path.join(__dirname, 'growth-dashboard.py');
+    const result = spawnSync('python3', [script, `--artistId=${artistId}`], { encoding: 'utf8' });
+    if (result.status !== 0) {
+      throw new Error(result.stderr.trim());
+    }
+    return { statusCode: 200, headers, body: result.stdout };
+  } catch (err) {
+    return { statusCode: 500, headers, body: JSON.stringify({ error: err.message }) };
+  }
+};

--- a/lambda/growthDashboard/package.json
+++ b/lambda/growthDashboard/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "growthDashboard",
+  "version": "1.0.0"
+}

--- a/lambda/spotifyArtistFetcher/index.js
+++ b/lambda/spotifyArtistFetcher/index.js
@@ -1,0 +1,97 @@
+const fetch = require('node-fetch');
+const { DynamoDBClient, PutItemCommand } = require('@aws-sdk/client-dynamodb');
+const { SecretsManagerClient, GetSecretValueCommand } = require('@aws-sdk/client-secrets-manager');
+const fs = require('fs');
+const path = require('path');
+
+const REGION = process.env.AWS_REGION || 'eu-central-1';
+const TABLE = process.env.SPOTIFY_TABLE || 'SpotifyArtistData';
+const ARTIST_IDS = (process.env.ARTIST_IDS || '').split(',').map(s => s.trim()).filter(Boolean);
+const ddb = new DynamoDBClient({ region: REGION });
+const secretsClient = new SecretsManagerClient({ region: REGION });
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'OPTIONS,POST,GET',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Content-Type': 'application/json'
+};
+let creds;
+
+async function getCreds() {
+  if (creds) return creds;
+  if (process.env.SPOTIFY_CREDENTIALS_SECRET) {
+    const { SecretString } = await secretsClient.send(
+      new GetSecretValueCommand({ SecretId: process.env.SPOTIFY_CREDENTIALS_SECRET })
+    );
+    creds = JSON.parse(SecretString);
+  } else {
+    // Allow local development by loading credentials from spotify-credentials.json
+    try {
+      const filePath = path.resolve(__dirname, '../../../spotify-credentials.json');
+      const file = fs.readFileSync(filePath, 'utf8');
+      creds = JSON.parse(file);
+    } catch {
+      creds = {
+        client_id: process.env.SPOTIFY_CLIENT_ID,
+        client_secret: process.env.SPOTIFY_CLIENT_SECRET
+      };
+    }
+  }
+  return creds;
+}
+
+async function getToken() {
+  const { client_id: id, client_secret: secret } = await getCreds();
+  const auth = Buffer.from(`${id}:${secret}`).toString('base64');
+  const res = await fetch('https://accounts.spotify.com/api/token', {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${auth}`,
+      'Content-Type': 'application/x-www-form-urlencoded'
+    },
+    body: 'grant_type=client_credentials'
+  });
+  const json = await res.json();
+  return json.access_token;
+}
+
+async function getArtistData(token, artistId) {
+  const headers = { Authorization: `Bearer ${token}` };
+  const base = 'https://api.spotify.com/v1';
+  const profile = await fetch(`${base}/artists/${artistId}`, { headers }).then(r => r.json());
+  const top = await fetch(`${base}/artists/${artistId}/top-tracks?market=US`, { headers }).then(r => r.json());
+  const cats = await fetch(`${base}/browse/categories?limit=5`, { headers }).then(r => r.json());
+  return { profile, top: top.tracks || [], categories: cats.categories?.items || [] };
+}
+
+exports.handler = async (event = {}) => {
+  if (event.httpMethod === 'OPTIONS') {
+    return {
+      statusCode: 200,
+      headers: corsHeaders,
+      body: ''
+    };
+  }
+  if (!ARTIST_IDS.length) throw new Error('No ARTIST_IDS configured');
+  const token = await getToken();
+  const week = new Date().toISOString().slice(0,10);
+  const tasks = ARTIST_IDS.map(async id => {
+    const data = await getArtistData(token, id);
+    const item = {
+      artist_id: { S: id },
+      week_start: { S: week },
+      name: { S: data.profile.name || '' },
+      followers: { N: String(data.profile.followers?.total || 0) },
+      popularity: { N: String(data.profile.popularity || 0) },
+      top_tracks: { S: JSON.stringify(data.top.map(t => ({ id: t.id, name: t.name }))) },
+      trending: { S: JSON.stringify(data.categories.map(c => c.name)) }
+    };
+    await ddb.send(new PutItemCommand({ TableName: TABLE, Item: item }));
+  });
+  await Promise.all(tasks);
+  return {
+    statusCode: 200,
+    headers: corsHeaders,
+    body: JSON.stringify({ saved: ARTIST_IDS.length })
+  };
+};

--- a/lambda/spotifyArtistFetcher/package.json
+++ b/lambda/spotifyArtistFetcher/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "spotifyArtistFetcher",
+  "version": "1.0.0",
+  "dependencies": {
+    "node-fetch": "^2.6.7"
+  }
+}


### PR DESCRIPTION
## Summary
- create individual folders for spotifyArtistFetcher and growthDashboard lambdas
- add wrapper Lambda for growth dashboard that runs existing Python script
- include package manifests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688930bdf5608324944ca4b1d692ca08