### PR TITLE
Update node-fetch to v3.3.2

### DIFF
--- a/backend/handlers/dailyTrendingPost/index.js
+++ b/backend/handlers/dailyTrendingPost/index.js
@@ -1,5 +1,6 @@
 const { BedrockRuntimeClient, InvokeModelCommand } = require('@aws-sdk/client-bedrock-runtime');
-const fetch = require('node-fetch');
+const fetch = (...args) =>
+  import('node-fetch').then(({ default: fetch }) => fetch(...args));
 const { headers } = require('../../../lambda/shared/cors-headers');
 
 const REGION = process.env.AWS_REGION || 'eu-central-1';

--- a/backend/handlers/facebookPoster/index.js
+++ b/backend/handlers/facebookPoster/index.js
@@ -1,4 +1,5 @@
-const fetch = require('node-fetch');
+const fetch = (...args) =>
+  import('node-fetch').then(({ default: fetch }) => fetch(...args));
 const { BedrockRuntimeClient, InvokeModelCommand } = require('@aws-sdk/client-bedrock-runtime');
 const { headers } = require('../../../lambda/shared/cors-headers');
 

--- a/backend/handlers/spotifyArtistFetcher/index.js
+++ b/backend/handlers/spotifyArtistFetcher/index.js
@@ -1,4 +1,5 @@
-const fetch = require('node-fetch');
+const fetch = (...args) =>
+  import('node-fetch').then(({ default: fetch }) => fetch(...args));
 const { DynamoDBClient, PutItemCommand } = require('@aws-sdk/client-dynamodb');
 const { SecretsManagerClient, GetSecretValueCommand } = require('@aws-sdk/client-secrets-manager');
 const fs = require('fs');

--- a/lambda/spotifyArtistFetcher/index.js
+++ b/lambda/spotifyArtistFetcher/index.js
@@ -1,4 +1,5 @@
-const fetch = require('node-fetch');
+const fetch = (...args) =>
+  import('node-fetch').then(({ default: fetch }) => fetch(...args));
 const { DynamoDBClient, PutItemCommand } = require('@aws-sdk/client-dynamodb');
 const { SecretsManagerClient, GetSecretValueCommand } = require('@aws-sdk/client-secrets-manager');
 const fs = require('fs');

--- a/lambda/spotifyArtistFetcher/package-lock.json
+++ b/lambda/spotifyArtistFetcher/package-lock.json
@@ -1,11 +1,13 @@
 {
-  "name": "decodedGIT",
+  "name": "spotifyArtistFetcher",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "spotifyArtistFetcher",
+      "version": "1.0.0",
       "dependencies": {
-        "node-cron": "^3.0.3",
         "node-fetch": "^3.3.2"
       }
     },
@@ -53,18 +55,6 @@
         "node": ">=12.20.0"
       }
     },
-    "node_modules/node-cron": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
-      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
-      "license": "ISC",
-      "dependencies": {
-        "uuid": "8.3.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -101,15 +91,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/lambda/spotifyArtistFetcher/package.json
+++ b/lambda/spotifyArtistFetcher/package.json
@@ -2,6 +2,6 @@
   "name": "spotifyArtistFetcher",
   "version": "1.0.0",
   "dependencies": {
-    "node-fetch": "^2.6.7"
+    "node-fetch": "^3.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
   },
   "dependencies": {
     "node-cron": "^3.0.3",
-    "node-fetch": "^2.6.7"
+    "node-fetch": "^3.3.2"
   }
 }

--- a/scripts/dailyContentAgent.js
+++ b/scripts/dailyContentAgent.js
@@ -1,6 +1,7 @@
 const fs = require('fs/promises');
 const path = require('path');
-const fetch = require('node-fetch');
+const fetch = (...args) =>
+  import('node-fetch').then(({ default: fetch }) => fetch(...args));
 const { BedrockRuntimeClient, InvokeModelCommand } = require('@aws-sdk/client-bedrock-runtime');
 
 // Load environment variables from .env if present

--- a/scripts/package-lambdas.sh
+++ b/scripts/package-lambdas.sh
@@ -7,7 +7,7 @@ cd "$HANDLERS_DIR"
 for dir in */ ; do
   if [ -f "$dir/package.json" ]; then
     echo "Installing deps for $dir"
-    (cd "$dir" && npm install node-fetch@^3.2.0)
+    (cd "$dir" && npm install node-fetch@^3.3.2)
     zip_file="${dir%/}.zip"
     echo "Creating $zip_file"
     (cd "$dir" && zip -r "../$zip_file" . -x "../$zip_file")

--- a/scripts/socialPostScheduler.js
+++ b/scripts/socialPostScheduler.js
@@ -2,7 +2,8 @@
 // Uses Meta Graph API, Snapchat API, and YouTube to queue posts.
 // Requires access tokens via environment variables.
 
-const fetch = require('node-fetch');
+const fetch = (...args) =>
+  import('node-fetch').then(({ default: fetch }) => fetch(...args));
 
 async function postToInstagram(caption, mediaUrl) {
   const token = process.env.INSTAGRAM_TOKEN;

--- a/scripts/trendingReposter.js
+++ b/scripts/trendingReposter.js
@@ -1,7 +1,8 @@
 // Trending Topic Reposter
 // Gathers trending topics and reposts content with hashtags.
 
-const fetch = require('node-fetch');
+const fetch = (...args) =>
+  import('node-fetch').then(({ default: fetch }) => fetch(...args));
 
 async function getTwitterTrends() {
   // Placeholder for Twitter API call

--- a/scripts/verify-api-connectivity.js
+++ b/scripts/verify-api-connectivity.js
@@ -1,5 +1,6 @@
 // verify-api-connectivity.js
-const fetch = require('node-fetch'); // npm install node-fetch@2
+const fetch = (...args) =>
+  import('node-fetch').then(({ default: fetch }) => fetch(...args));
 
 // List your API endpoints here for each landing page section
 const apiEndpoints = [


### PR DESCRIPTION
## Summary
- upgrade root and lambda `package.json` to `node-fetch@^3.3.2`
- regenerate `package-lock.json` files
- update scripts and Lambda handlers to dynamically import `node-fetch`
- adjust packaging script to install the newer version

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68893685b0148324bdbc642a52f9181d