### PR TITLE
feat: use dynamic artist ids

### DIFF
--- a/frontend/ROADMAP.md
+++ b/frontend/ROADMAP.md
@@ -1,0 +1,26 @@
+# ROADMAP: Spotify OAuth and User-Level Scopes
+
+This project currently authenticates with Spotify using client credentials and artist-level data.
+To support user-specific features such as playlist access, implement the following steps:
+
+1. **OAuth Authorization Code Flow**
+   - Register the app with Spotify and enable the Authorization Code flow.
+   - Add a backend route `/auth/spotify/callback` to exchange the authorization code for access and refresh tokens.
+   - Store tokens per user, keyed by their artist ID from `ArtistManager`.
+
+2. **Request User Scopes**
+   - When directing users to Spotify for login, include the desired scopes (e.g. `playlist-read-private`).
+   - After successful callback, save the granted scopes along with tokens.
+
+3. **Frontend Integration**
+   - After authentication, call the backend to retrieve the stored tokens for the logged-in artist.
+   - Use these tokens to access user-level Spotify APIs (playlists, saved tracks, etc.).
+
+4. **Token Refresh**
+   - Implement a refresh-token mechanism on the backend to keep user tokens valid without requiring re-login.
+
+5. **Testing and Rollout**
+   - Start with limited scopes and a small test group of artists.
+   - Expand scope coverage as features (playlist editing, follows, etc.) are added.
+
+This roadmap ensures any artist logging into the platform can authorize Spotify and access their personalized data securely.

--- a/frontend/public/api-test.html
+++ b/frontend/public/api-test.html
@@ -13,7 +13,7 @@
     </style>
 </head>
 <body>
-    <h1> Rue De Vivre API Connection Tester</h1>
+    <h1> API Connection Tester</h1>
     <p>This page tests your API connections and helps debug CORS issues.</p>
     
     <button onclick="testAllAPIs()"> Test All APIs</button>
@@ -30,11 +30,11 @@
         results.innerHTML = '<h3> Testing all APIs...</h3>';
         
         const endpoints = [
-            { name: 'Catalog API', url: '/catalog?artistId=ruedevivre' },
-            { name: 'Analytics API', url: '/api/analytics?artistId=ruedevivre' },
-            { name: 'Portfolio API', url: '/accounting?artistId=ruedevivre' },
-            { name: 'Spotify API', url: '/spotify?artistId=ruedevivre' },
-            { name: 'Trends API', url: '/trends?artistId=ruedevivre' }
+            { name: 'Catalog API', url: '/catalog?artistId=demo_artist' },
+            { name: 'Analytics API', url: '/api/analytics?artistId=demo_artist' },
+            { name: 'Portfolio API', url: '/accounting?artistId=demo_artist' },
+            { name: 'Spotify API', url: '/spotify?artistId=demo_artist' },
+            { name: 'Trends API', url: '/trends?artistId=demo_artist' }
         ];
         
         for (const endpoint of endpoints) {
@@ -46,12 +46,12 @@
     
     async function testCatalogOnly() {
         document.getElementById('results').innerHTML = '<h3> Testing Catalog API...</h3>';
-        await testEndpoint({ name: 'Catalog API', url: '/catalog?artistId=ruedevivre' });
+        await testEndpoint({ name: 'Catalog API', url: '/catalog?artistId=demo_artist' });
     }
     
     async function testAnalyticsOnly() {
         document.getElementById('results').innerHTML = '<h3> Testing Analytics API...</h3>';
-        await testEndpoint({ name: 'Analytics API', url: '/api/analytics?artistId=ruedevivre' });
+        await testEndpoint({ name: 'Analytics API', url: '/api/analytics?artistId=demo_artist' });
     }
     
     async function testEndpoint(endpoint) {

--- a/frontend/public/health.json
+++ b/frontend/public/health.json
@@ -6,5 +6,5 @@
         "analytics": "Using fallback data if API unavailable",
         "frontend": "React app running with error handling"
     },
-    "message": "Rue De Vivre Analytics - All systems operational with graceful fallbacks"
+    "message": "Analytics system operational with graceful fallbacks"
 }

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -171,7 +171,7 @@
         },
 
         social: {
-          youtube: 'https://www.youtube.com/@RueDeVivre',
+          youtube: '',
           instagram: 'https://www.instagram.com/kaiserinstreetwear/',
           discord: 'https://discord.com/invite/6Txu7wUW'
         }
@@ -225,9 +225,9 @@
 
         <!-- Social & Content -->
         <div class="footer-section">
-          <h3>🌐 Connect with RDV</h3>
+          <h3>🌐 Connect with Us</h3>
           <ul class="footer-links">
-            <li><a href="https://www.youtube.com/@RueDeVivre" target="_blank">📺 YouTube</a></li>
+            <li><a href="#" target="_blank">📺 YouTube</a></li>
             <li><a href="https://www.instagram.com/kaiserinstreetwear/" target="_blank">📷 Instagram</a></li>
           </ul>
         </div>

--- a/frontend/src/components/Dashboard.js
+++ b/frontend/src/components/Dashboard.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import './Dashboard.css';
+import { getArtistId } from '../state/ArtistManager.js';
 
 const Dashboard = ({ user, username, onSignOut }) => {
     const [dashboardData, setDashboardData] = useState(null);
@@ -16,9 +17,10 @@ const Dashboard = ({ user, username, onSignOut }) => {
 
         try {
             // Use fallback data for demo
+            const artist = getArtistId();
             const fallbackData = {
                 catalog: {
-                    artist: 'Rue De Vivre',
+                    artist,
                     totalTracks: 40,
                     totalStreams: 125000,
                     monthlyRevenue: 1247.89
@@ -86,7 +88,7 @@ const Dashboard = ({ user, username, onSignOut }) => {
             <header className="dashboard-header">
                 <div className="dashboard-nav">
                     <div className="dashboard-logo">
-                        <h1> Rue De Vivre Analytics</h1>
+                        <h1> {getArtistId()} Analytics</h1>
                     </div>
                     <div className="user-controls">
                         <span className="welcome-text">Welcome, {username}</span>

--- a/frontend/src/components/Footer.js
+++ b/frontend/src/components/Footer.js
@@ -60,14 +60,6 @@ export default function Footer() {
             YouTube
           </a>
           <a
-            href="https://www.youtube.com/@ruedevivre/releases"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline"
-          >
-            Rue De Vivre YouTube
-          </a>
-          <a
             href="https://www.instagram.com/kaiserinstreetwear/"
             target="_blank"
             rel="noopener noreferrer"

--- a/frontend/src/components/SpotifyModule.js
+++ b/frontend/src/components/SpotifyModule.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { DashboardAPI } from '../api/dashboard.js';
+import { getArtistId } from '../state/ArtistManager.js';
 
 function SpotifyModule() {
   const [data, setData] = useState(null);
@@ -7,7 +8,8 @@ function SpotifyModule() {
   useEffect(() => {
     async function fetchSpotify() {
       try {
-        const res = await DashboardAPI.getSpotifyData({ artistId: 'RueDeVivre' });
+        const artistId = getArtistId();
+        const res = await DashboardAPI.getSpotifyData({ artistId });
         setData(res);
       } catch (err) {
         console.error('spotify fetch error', err);

--- a/frontend/src/context/AuthContext.js
+++ b/frontend/src/context/AuthContext.js
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import cognitoAuthService from '../services/CognitoAuthService.js';
 import { getCognitoTokenFromUrl } from '../utils/getCognitoToken.js';
+import { setArtistIdFromUser } from '../state/ArtistManager.js';
 
 const AuthContext = createContext();
 
@@ -23,6 +24,7 @@ export function AuthProvider({ children }) {
         } catch {}
         setUser(storedToken);
         setIsAuthenticated(true);
+        await setArtistIdFromUser();
         setLoading(false);
         return;
       }
@@ -33,6 +35,7 @@ export function AuthProvider({ children }) {
           setUser(result.user);
           setUsername(result.username);
           setIsAuthenticated(true);
+          await setArtistIdFromUser();
         } else {
           console.warn('Session expired or invalid. Clearing auth state.');
           await cognitoAuthService.signOut();
@@ -67,6 +70,7 @@ export function AuthProvider({ children }) {
       setUser(result.user);
       setUsername(result.username);
       setIsAuthenticated(true);
+      await setArtistIdFromUser();
     }
     return result;
   };

--- a/frontend/src/pages/Accounting.jsx
+++ b/frontend/src/pages/Accounting.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { DashboardAPI } from '../api/dashboard';
+import { getArtistId } from '../state/ArtistManager.js';
 
 const API_BASE = process.env.REACT_APP_API_BASE || '/api/dashboard';
 
@@ -9,7 +10,8 @@ function Accounting() {
   useEffect(() => {
     async function fetchAccounting() {
       try {
-        const data = await DashboardAPI.getAccounting({ artistId: 'RueDeVivre' });
+        const artistId = getArtistId();
+        const data = await DashboardAPI.getAccounting({ artistId });
         setSummary(data);
       } catch (err) {
         console.error('fetch accounting error', err);
@@ -19,7 +21,8 @@ function Accounting() {
   }, []);
 
   const downloadCsv = () => {
-    window.location.href = `${API_BASE}/accounting/export?artist_id=RueDeVivre`;
+    const artistId = getArtistId();
+    window.location.href = `${API_BASE}/accounting/export?artist_id=${artistId}`;
   };
 
   return (

--- a/frontend/src/pages/ArtistDashboard.js
+++ b/frontend/src/pages/ArtistDashboard.js
@@ -3,6 +3,7 @@ import { DashboardAPI } from '../api/dashboard.js';
 import { getCognitoTokenFromUrl } from '../utils/getCognitoToken.js';
 import SpotifyModule from '../components/SpotifyModule.js';
 import LogoutButton from '../components/LogoutButton.jsx';
+import { getArtistId } from '../state/ArtistManager.js';
 
 const CLIENT_ID = process.env.REACT_APP_SPOTIFY_CLIENT_ID;
 const REDIRECT_URI = process.env.REACT_APP_SPOTIFY_REDIRECT_URI ||
@@ -53,7 +54,8 @@ function ArtistDashboard() {
 
     async function loadData() {
       try {
-        const data = await DashboardAPI.getAccounting({ artistId: 'RueDeVivre' });
+        const artistId = getArtistId();
+        const data = await DashboardAPI.getAccounting({ artistId });
         setAccounting(data);
       } catch (err) {
         setError('Failed to load dashboard data.');

--- a/frontend/src/services/CatalogService.js
+++ b/frontend/src/services/CatalogService.js
@@ -2,7 +2,7 @@ class CatalogService {
   // If you have live DynamoDB tables, replace these mock methods with real API/database calls.
   // Remove the dummy/mock data and implement actual fetch logic as needed.
 
-  async getCatalog(artistId = 'ruedevivre') {
+  async getCatalog(artistId = 'demo_artist') {
     // Example: Replace this block with a real fetch from your backend or DynamoDB
     // return fetch(`/api/catalog?artistId=${artistId}`).then(res => res.json());
     try {
@@ -11,42 +11,42 @@ class CatalogService {
       return [
         {
           title: 'Summer Nights',
-          artistName: 'Rue de Vivre',
+          artistName: artistId,
           genre: 'Electronic',
           duration: '3:42',
           releaseDate: '2024-06-15'
         },
         {
           title: 'Digital Dreams',
-          artistName: 'Rue de Vivre',
+          artistName: artistId,
           genre: 'Synthwave',
           duration: '4:18',
           releaseDate: '2024-05-20'
         },
         {
           title: 'Neon Lights',
-          artistName: 'Rue de Vivre',
+          artistName: artistId,
           genre: 'Electronic',
           duration: '3:55',
           releaseDate: '2024-04-10'
         },
         {
           title: 'City Pulse',
-          artistName: 'Rue de Vivre',
+          artistName: artistId,
           genre: 'Ambient',
           duration: '5:12',
           releaseDate: '2024-03-25'
         },
         {
           title: 'Midnight Drive',
-          artistName: 'Rue de Vivre',
+          artistName: artistId,
           genre: 'Synthwave',
           duration: '4:33',
           releaseDate: '2024-02-14'
         },
         {
           title: 'Electric Sunset',
-          artistName: 'Rue de Vivre',
+          artistName: artistId,
           genre: 'Electronic',
           duration: '3:27',
           releaseDate: '2024-01-30'
@@ -58,7 +58,7 @@ class CatalogService {
     }
   }
 
-  async getSpotifyData(artistId = 'ruedevivre') {
+  async getSpotifyData(artistId = 'demo_artist') {
     // Replace with real Spotify API call if available
     try {
       // Mock Spotify data for demo (REMOVE if using live data)
@@ -76,7 +76,7 @@ class CatalogService {
     }
   }
 
-  async getAccountingData(artistId = 'RueDeVivre') {
+  async getAccountingData(artistId = 'demo_artist') {
     // Replace with real accounting data fetch if available
     try {
       // Mock accounting data for demo (REMOVE if using live data)

--- a/frontend/src/state/ArtistManager.js
+++ b/frontend/src/state/ArtistManager.js
@@ -8,10 +8,10 @@ export const setArtistId = (newId) => {
 };
 
 export const setArtistIdFromUser = async () => {
-  const user = await cognitoAuthService.getCurrentUser();
-  const email = user.email;
-  const artistId = mapEmailToArtistId(email);
-  setArtistId(artistId);
+  const result = await cognitoAuthService.getCurrentUser();
+  const email = result.user; // currentUser.getUsername() returns the email
+  const derivedId = mapEmailToArtistId(email);
+  setArtistId(derivedId);
 };
 
 function mapEmailToArtistId(email) {

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -1,4 +1,4 @@
-﻿/* Rue De Vivre Analytics Dashboard Styles */
+/* Analytics Dashboard Styles */
 * {
     margin: 0;
     padding: 0;

--- a/lambda/enhanced-accounting-dashboard.js
+++ b/lambda/enhanced-accounting-dashboard.js
@@ -15,7 +15,7 @@ exports.handler = async (event) => {
     }
     
     try {
-        const artistId = event.queryStringParameters?.artistId || 'RueDeVivre';
+        const artistId = event.queryStringParameters?.artistId || 'unknown_artist';
         
         // Get trend prediction data
         const trendsResponse = await dynamodb.scan({
@@ -204,7 +204,7 @@ exports.handler = async (event) => {
             body: JSON.stringify({
                 error: 'Failed to load accounting data',
                 message: error.message,
-                artist: 'RueDeVivre',
+                artist: artistId,
                 fallback: { totalTracks: 0, message: 'Investment data temporarily unavailable' }
             })
         };

--- a/lambda/growth-dashboard-lambda/growth-dashboard.py
+++ b/lambda/growth-dashboard-lambda/growth-dashboard.py
@@ -8,9 +8,9 @@ import sys
 DYNAMO_GROWTH_TABLE = 'prod-GrowthMetrics-decodedmusic-backend'
 DYNAMO_INSIGHTS_TABLE = 'prod-SpotifyInsights-decodedmusic-backend'
 DYNAMO_CATALOG_TABLE = 'prod-DecodedCatalog-decodedmusic-backend'
-SPOTIFY_ARTIST_ID = '293x3NAIGPR4RCJrFkzs0P'  # Spotify Artist ID
-CATALOG_ARTIST_ID = 'ruedevivre'  # Programmatic identifier for DynamoDB queries
-ARTIST_NAME = 'Rue De Vivre'  # Display name for UI and logs
+SPOTIFY_ARTIST_ID = ''  # Spotify Artist ID (set per artist)
+CATALOG_ARTIST_ID = ''  # Programmatic identifier for DynamoDB queries
+ARTIST_NAME = ''  # Display name for UI and logs
 
 dynamodb = boto3.resource('dynamodb')
 

--- a/lambda/growthDashboard/growth-dashboard.py
+++ b/lambda/growthDashboard/growth-dashboard.py
@@ -8,9 +8,9 @@ import sys
 DYNAMO_GROWTH_TABLE = 'prod-GrowthMetrics-decodedmusic-backend'
 DYNAMO_INSIGHTS_TABLE = 'prod-SpotifyInsights-decodedmusic-backend'
 DYNAMO_CATALOG_TABLE = 'prod-DecodedCatalog-decodedmusic-backend'
-SPOTIFY_ARTIST_ID = '293x3NAIGPR4RCJrFkzs0P'  # Spotify Artist ID
-CATALOG_ARTIST_ID = 'ruedevivre'  # Programmatic identifier for DynamoDB queries
-ARTIST_NAME = 'Rue De Vivre'  # Display name for UI and logs
+SPOTIFY_ARTIST_ID = ''  # Spotify Artist ID (set per artist)
+CATALOG_ARTIST_ID = ''  # Programmatic identifier for DynamoDB queries
+ARTIST_NAME = ''  # Display name for UI and logs
 
 dynamodb = boto3.resource('dynamodb')
 

--- a/lambda/index.js
+++ b/lambda/index.js
@@ -23,9 +23,11 @@ exports.handler = async (event) => {
         }).promise();
         
         const latestTrends = trendsResponse.Items[0]?.analysis_data || {};
-        
+
+        const artist = event.queryStringParameters?.artist_id || 'unknown_artist';
+
         const spotifyData = {
-            artist: 'Rue De Vivre',
+            artist,
             followers: 15,
             verified: false,
             monthlyListeners: 1250,
@@ -80,7 +82,7 @@ exports.handler = async (event) => {
             body: JSON.stringify({
                 error: 'Failed to load Spotify data',
                 message: error.message,
-                fallback: { artist: 'Rue De Vivre', followers: 0 }
+                fallback: { artist, followers: 0 }
             })
         };
     }


### PR DESCRIPTION
## Summary
- derive artist id from logged in user and use it across dashboard, accounting, Spotify module and services
- drop hardcoded Rue De Vivre references in lambda APIs and frontend/public assets
- add roadmap for future Spotify OAuth scopes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688bfe99188c8324a9344ffa733667c2