### PR TITLE
fix: refine BedrockService error handling

### DIFF
--- a/frontend/src/services/BedrockService.js
+++ b/frontend/src/services/BedrockService.js
@@ -23,7 +23,9 @@ export async function generateContent(prompt) {
 
     return response.data;
   } catch (error) {
-    console.error('Error generating content with AWS Bedrock:', error);
+    const message =
+      error?.response?.data?.message || error.message || String(error);
+    console.error('Error generating content with AWS Bedrock:', message);
     throw error;
   }
 }


### PR DESCRIPTION
## Summary
- refine BedrockService error handling to report concise message

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688d0b3926488324b80cba436b76a6aa