### PR TITLE
Remove Cognito requirement from Bedrock service

### DIFF
--- a/frontend/src/services/BedrockService.js
+++ b/frontend/src/services/BedrockService.js
@@ -9,14 +9,12 @@ const bedrockApiUrl =
 
 export async function generateContent(prompt) {
   try {
-    const token = localStorage.getItem('cognito_access_token');
     const response = await axios.post(
       bedrockApiUrl,
       { prompt },
       {
         headers: {
           'Content-Type': 'application/json',
-          ...(token && { Authorization: `Bearer ${token}` }),
         },
       }
     );


### PR DESCRIPTION
## Summary
- remove Cognito token header from BedrockService so it no longer requires Cognito authentication

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688d0da6b6dc83248ef0e2b6000a63fe